### PR TITLE
Generate the Union setter for String/String16 to call the builder only once.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ buildNumber.properties
 .project
 .settings/
 .checkstyle
+.idea/
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,3 @@ buildNumber.properties
 .project
 .settings/
 .checkstyle
-.idea/
-*.iml

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/UnionFlyweightGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/UnionFlyweightGenerator.java
@@ -897,20 +897,22 @@ public final class UnionFlyweightGenerator extends ClassSpecGenerator
                 if ("StringFW".equals(className.simpleName()) || "String16FW".equals(className.simpleName()))
                 {
                     CodeBlock.Builder codeBlock = CodeBlock.builder();
+                    ClassName builderType = className.nestedClass("Builder");
 
                     // TODO: handle optional fields
                     codeBlock.beginControlFlow("if (value == null)")
                         .addStatement("limit(offset() + $L)", offset(name))
                         .nextControlFlow("else")
                         .addStatement("kind($L)", kind(name))
-                        .addStatement("$L().set(value, $T.UTF_8)", name, StandardCharsets.class);
+                        .addStatement("$T $L = $L()", builderType, name, name)
+                        .addStatement("$L.set(value, $T.UTF_8)", name, StandardCharsets.class);
 
                     if (nextType instanceof ParameterizedTypeName)
                     {
-                        codeBlock.addStatement("$L($L().build().limit())", nextName, name);
+                        codeBlock.addStatement("$L($L.build().limit())", nextName, name);
                     }
 
-                    codeBlock.addStatement("limit($L().build().limit())", name)
+                    codeBlock.addStatement("limit($L.build().limit())", name)
                         .endControlFlow()
                         .addStatement("return this");
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/UnionOctetsFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/UnionOctetsFWTest.java
@@ -51,6 +51,7 @@ public class UnionOctetsFWTest
         unionRO.wrap(buffer,  0,  limit);
         assertEquals("1234", unionRO.octets4().get((b, o, m) -> b.getStringWithoutLengthUtf8(o, m - o)));
         assertEquals(0, unionRO.octets16().sizeof());
+        assertEquals(null, unionRO.string1().asString());
     }
 
     @Test
@@ -63,6 +64,29 @@ public class UnionOctetsFWTest
         unionRO.wrap(buffer,  0,  limit);
         assertEquals("1234567890123456", unionRO.octets16().get((b, o, m) -> b.getStringWithoutLengthUtf8(o, m - o)));
         assertEquals(0, unionRO.octets4().sizeof());
+        assertEquals(null, unionRO.string1().asString());
+    }
+
+    @Test
+    public void shouldSetString1()
+    {
+        int limit = unionRW.wrap(buffer, 0, buffer.capacity())
+            .string1("valueOfString1")
+            .build()
+            .limit();
+        unionRO.wrap(buffer,  0,  limit);
+        assertEquals("valueOfString1", unionRO.string1().asString());
+        assertEquals(0, unionRO.octets4().sizeof());
+        assertEquals(0, unionRO.octets16().sizeof());
+    }
+
+    @Test
+    public void shouldSetStringWithValueNull()
+    {
+        int limit = unionRW.wrap(buffer, 10, buffer.capacity())
+            .string1(null).build().limit();
+        unionRO.wrap(buffer,  0,  limit);
+        assertEquals(null, unionRO.string1().asString());
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -58,6 +58,7 @@ scope test
         {
             case 1: octets[4] octets4;
             case 2: octets[16] octets16;
+            case 3: string string1;
         }
     
         struct Integers


### PR DESCRIPTION
Should fix issue #38 . Could use some hints on how to add a test for `nextType instanceof ParameterizedTypeName`, see: https://github.com/reaktivity/nukleus-maven-plugin/compare/develop...Anisotrop:fix.union.stringfw?expand=1#diff-446884d7c2e3e578b1f008a066b4e856R910.