### PR TITLE
Added support for using varint32 or varint64 field as size field fo an octets field.

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/AstMemberNode.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/AstMemberNode.java
@@ -37,6 +37,7 @@ public final class AstMemberNode extends AstNode
     private final AstByteOrder byteOrder;
     private final boolean isArray;
 
+    private AstType sizeType;
     private boolean usedAsSize;
 
 
@@ -102,6 +103,11 @@ public final class AstMemberNode extends AstNode
         return sizeName;
     }
 
+    public AstType sizeType()
+    {
+        return sizeType;
+    }
+
     public Object defaultValue()
     {
         return defaultValue;
@@ -147,6 +153,11 @@ public final class AstMemberNode extends AstNode
         String size = this.size == 0 ? this.sizeName : Integer.toString(this.size);
         return String.format("MEMBER [name=%s, size=%s, types=%s, unsignedType=%s, defaultValue=%s, byteOrder=%s]",
                 name, size, types, unsignedType, defaultValue, byteOrder);
+    }
+
+    public void sizeType(AstType sizeType)
+    {
+        this.sizeType = sizeType;
     }
 
     public void usedAsSize(boolean value)

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/AstStructNode.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/AstStructNode.java
@@ -139,6 +139,7 @@ public final class AstStructNode extends AstNode
                 if (sizeField.isPresent())
                 {
                     AstMemberNode size = sizeField.get();
+                    member.sizeType(size.type());
                     if (size.defaultValue() != null)
                     {
                         throw new IllegalArgumentException(format(
@@ -146,8 +147,24 @@ public final class AstStructNode extends AstNode
                                 member.sizeName(), member.name()));
                     }
                     boolean defaultsToNull = member.defaultValue() == NULL_DEFAULT;
-                    if (defaultsToNull && !size.type().isSignedInteger())
+                    boolean sizeIsVarint = size.type() == AstType.VARINT32 || size.type() == AstType.VARINT64;
+                    if (sizeIsVarint)
                     {
+                        if (member.type() == AstType.OCTETS)
+                        {
+                            size.usedAsSize(true);
+                        }
+                        else
+                        {
+                            throw new IllegalArgumentException(format(
+                                "Size field \"%s\" for field \"%s\" may not be of type varint",
+                                member.sizeName(), member.name()));
+                        }
+                    }
+                    else if (defaultsToNull && !size.type().isSignedInteger())
+                    {
+                        Object sizeType = size.type();
+                        System.out.println(sizeType);
                         throw new IllegalArgumentException(format(
                                 "Size field \"%s\" for field \"%s\" defaulting to null must be a signed integer type",
                                 member.sizeName(), member.name()));

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/visit/StructVisitor.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/visit/StructVisitor.java
@@ -89,6 +89,8 @@ public final class StructVisitor extends AstNode.Visitor<Collection<TypeSpecGene
         AstType memberUnsignedType = memberNode.unsignedType();
         int size = memberNode.size();
         String sizeName = memberNode.sizeName();
+        TypeName sizeTypeName = resolver.resolveType(memberNode.sizeType());
+
         boolean usedAsSize = memberNode.usedAsSize();
         Object defaultValue = memberNode.defaultValue();
         AstByteOrder byteOrder = memberNode.byteOrder();
@@ -104,8 +106,8 @@ public final class StructVisitor extends AstNode.Visitor<Collection<TypeSpecGene
                     .toArray(new TypeName[0]);
             ParameterizedTypeName memberTypeName = ParameterizedTypeName.get(rawType, typeArguments);
             TypeName memberUnsignedTypeName = resolver.resolveType(memberUnsignedType);
-            generator.addMember(memberName, memberTypeName, memberUnsignedTypeName, size, sizeName, false,
-                    defaultValue, byteOrder);
+            generator.addMember(memberName, memberTypeName, memberUnsignedTypeName, size, sizeName, sizeTypeName,
+                    false, defaultValue, byteOrder);
         }
         else
         {
@@ -116,8 +118,8 @@ public final class StructVisitor extends AstNode.Visitor<Collection<TypeSpecGene
                         " Unable to resolve type %s for field %s", memberType, memberName));
             }
             TypeName memberUnsignedTypeName = resolver.resolveType(memberUnsignedType);
-            generator.addMember(memberName, memberTypeName, memberUnsignedTypeName, size, sizeName, usedAsSize,
-                    defaultValue, byteOrder);
+            generator.addMember(memberName, memberTypeName, memberUnsignedTypeName, size, sizeName, sizeTypeName,
+                    usedAsSize, defaultValue, byteOrder);
         }
 
         return defaultResult();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatWithOctetsFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatWithOctetsFWTest.java
@@ -197,6 +197,7 @@ public class FlatWithOctetsFWTest
                 .octets1(b -> b.put("1234567890".getBytes(UTF_8)))
                 .string1("value1")
                 .octets2(b -> b.put("12345".getBytes(UTF_8)))
+                .lengthOctets3(3)
                 .octets3(b -> b.put("678".getBytes(UTF_8)))
                 .extension(b -> b.put("octetsValue".getBytes(UTF_8)))
                 .build()

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -53,7 +53,7 @@ scope test
             uint16 lengthOctets2;
             string string1;
             octets[lengthOctets2] octets2;
-            int32 lengthOctets3;
+            varint32 lengthOctets3;
             octets[lengthOctets3] octets3 = null;
             octets extension;
         }


### PR DESCRIPTION
Example:
```
        struct FlatWithOctets
        {
            uint32 fixed1 = 11;
            octets[10] octets1;
            uint16 lengthOctets2;
            string string1;
            octets[lengthOctets2] octets2;
            varint32 lengthOctets3;
            octets[lengthOctets3] octets3 = null;
            octets extension;
        }
```

NOTE: user must set the size field explicitly before setting the octets field, and when setting the octets field an exception is thrown if the size does not match. Defaulting to null is supported (in this case size field value defaults to -1).