### PR TITLE
Fixed runtime exception due to failure to default an octets field to null

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/StructFlyweightGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/StructFlyweightGenerator.java
@@ -1332,11 +1332,11 @@ public final class StructFlyweightGenerator extends ClassSpecGenerator
                     }
                     else
                     {
+                        code.addStatement("$L(b -> { })", priorDefaulted);
                         code.addStatement("int limit = limit()");
-                        code.addStatement("limit($L);;;", dynamicOffset(priorSizeName));
+                        code.addStatement("limit($L)", dynamicOffset(priorSizeName));
                         code.addStatement("$L(-1)", methodName(priorSizeName));
                         code.addStatement("limit(limit)");
-                        code.addStatement("$L(b -> { })", priorDefaulted);
                     }
                 }
                 else

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ArrayFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ArrayFWTest.java
@@ -38,14 +38,14 @@ public class ArrayFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatFWTest.java
@@ -33,7 +33,7 @@ public class FlatFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final FlatFW.Builder flatRW = new FlatFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatWithListFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatWithListFWTest.java
@@ -38,7 +38,7 @@ public class FlatWithListFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final FlatWithListFW.Builder flatRW = new FlatWithListFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatWithOctetsFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/FlatWithOctetsFWTest.java
@@ -35,7 +35,7 @@ public class FlatWithOctetsFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final FlatWithOctetsFW.Builder flatWithOctetsRW = new FlatWithOctetsFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/IntegerFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/IntegerFWTest.java
@@ -31,7 +31,7 @@ public class IntegerFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final IntegersFW.Builder integersRW = new IntegersFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/IntegerFixedArraysFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/IntegerFixedArraysFWTest.java
@@ -37,13 +37,13 @@ public class IntegerFixedArraysFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(150))
     {
         {
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final IntegerFixedArraysFW.Builder flyweightRW = new IntegerFixedArraysFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/IntegerVariableArraysFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/IntegerVariableArraysFWTest.java
@@ -27,7 +27,6 @@ import java.util.PrimitiveIterator;
 
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -136,13 +135,31 @@ public class IntegerVariableArraysFWTest
         flyweightRW.signed16Array(null);
     }
 
-    @Test
-    @Ignore // Issue #52
-    public void shouldFailToSetUnsigned64ArrayAfteSigned16Array()
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailToAppendUnsigned64ArrayWhenFollowingFieldsAreSet()
     {
         flyweightRW.wrap(buffer, 0, buffer.capacity())
         .appendSigned16Array((short) 0)
         .appendUnsigned64Array(12L)
+        .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailToAppendSigned64ArrayWhenFollowingFieldsAreSet()
+    {
+        flyweightRW.wrap(buffer, 0, buffer.capacity())
+        .appendArrayWithInt8Size(12)
+        .appendSigned16Array((short) 0)
+        .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldFailToAppendArraytWithInt8SizeWhenFollowingFieldsAreSet()
+    {
+        flyweightRW.wrap(buffer, 0, buffer.capacity())
+        .appendSigned16Array((short) 0)
+        .appendArrayWithInt16Size(12)
+        .appendArrayWithInt8Size(12)
         .build();
     }
 
@@ -284,8 +301,6 @@ public class IntegerVariableArraysFWTest
         .appendSigned16Array((short) -500)
         .build();
         flyweightRO.wrap(buffer, 0, 100);
-        System.out.println(flyweightRO);
-        System.out.println(flyweightRO);
         assertTrue(flyweightRO.toString().contains("unsigned64Array=[10, 1112345, 11234567]"));
         assertTrue(flyweightRO.toString().contains("signed16Array=[2, -500]"));
     }

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/NestedFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/NestedFWTest.java
@@ -33,7 +33,7 @@ public class NestedFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/OctetsFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/OctetsFWTest.java
@@ -32,7 +32,7 @@ public class OctetsFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final OctetsFW.Builder octetsRW = new OctetsFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/PotentialNameConflitsFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/PotentialNameConflitsFWTest.java
@@ -32,7 +32,7 @@ public class PotentialNameConflitsFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final PotentialNameConflictsFW.Builder potentialNameConflictsRW = new PotentialNameConflictsFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/RollFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/RollFWTest.java
@@ -33,7 +33,7 @@ public class RollFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final RollFW.Builder rollRW = new RollFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/String16FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/String16FWTest.java
@@ -44,7 +44,7 @@ public class String16FWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/StringFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/StringFWTest.java
@@ -34,7 +34,7 @@ public class StringFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final StringFW.Builder stringRW = new StringFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/UnionOctetsFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/UnionOctetsFWTest.java
@@ -32,7 +32,7 @@ public class UnionOctetsFWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xFF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final UnionOctetsFW.Builder unionRW = new UnionOctetsFW.Builder();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint32FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint32FWTest.java
@@ -31,14 +31,14 @@ public class Varint32FWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint64FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint64FWTest.java
@@ -31,14 +31,14 @@ public class Varint64FWTest
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
     private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
     {
         {
             // Make sure the code is not secretly relying upon memory being initialized to 0
-            setMemory(0, capacity(), (byte) 0xF);
+            setMemory(0, capacity(), (byte) 0xab);
         }
     };
 

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -55,6 +55,8 @@ scope test
             octets[lengthOctets2] octets2;
             varint32 lengthOctets3;
             octets[lengthOctets3] octets3 = null;
+            int32 lengthOctets4;
+            octets[lengthOctets4] octets4 = null;
             octets extension;
         }
         


### PR DESCRIPTION
The generated code was corrupting memory by setting the -1 length (to represent null) in the wrong location in the buffer, leading to runtime exceptions.

Also includes a fix for #52 (failure to detect incorrect ordering of appendXxx calls resulting in IndexOutOfBoundsException from build).

Also does a minor fix to all of the flyweight tests to ensure tests don't "accidentally" pass: initialize bytes in the test memory buffers to a value that is less likely to happen to be the correct one.