### PR TITLE
Fixed a bug in the generated tryWrap method in the varint flyweights …

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Varint32FlyweightGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Varint32FlyweightGenerator.java
@@ -154,7 +154,7 @@ public final class Varint32FlyweightGenerator extends ClassSpecGenerator
                 .addStatement("int pos = offset()")
                 .addStatement("byte b = (byte) 0")
                 .addStatement("final int maxPos = Math.min(pos + 5,  maxLimit())")
-                .beginControlFlow("while (pos <= maxPos && ((b = buffer().getByte(pos)) & 0x80) != 0)")
+                .beginControlFlow("while (pos < maxPos && ((b = buffer().getByte(pos)) & 0x80) != 0)")
                 .addStatement("pos++")
                 .endControlFlow()
                 .addStatement("int size = 1 + pos - offset()")

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Varint64FlyweightGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Varint64FlyweightGenerator.java
@@ -154,7 +154,7 @@ public final class Varint64FlyweightGenerator extends ClassSpecGenerator
                 .addStatement("int pos = offset()")
                 .addStatement("byte b = (byte) 0")
                 .addStatement("final int maxPos = Math.min(pos + 10,  maxLimit())")
-                .beginControlFlow("while (pos <= maxPos && ((b = buffer().getByte(pos)) & 0x80L) != 0)")
+                .beginControlFlow("while (pos < maxPos && ((b = buffer().getByte(pos)) & 0x80L) != 0)")
                 .addStatement("pos++")
                 .endControlFlow()
                 .addStatement("int size = 1 + pos - offset()")

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint32FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint32FWTest.java
@@ -69,7 +69,7 @@ public class Varint32FWTest
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[2]);
         buffer.putByte(0, (byte) 0x81);
         buffer.putByte(1, (byte) 0x81);
-        assertNull(varint32RO.tryWrap(buffer, 0, 1));
+        assertNull(varint32RO.tryWrap(buffer, 0, buffer.capacity()));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint64FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/Varint64FWTest.java
@@ -69,7 +69,7 @@ public class Varint64FWTest
         MutableDirectBuffer buffer = new UnsafeBuffer(new byte[2]);
         buffer.putByte(0, (byte) 0x81);
         buffer.putByte(1, (byte) 0x81);
-        assertNull(varint64RO.tryWrap(buffer, 0, 1));
+        assertNull(varint64RO.tryWrap(buffer, 0, buffer.capacity()));
     }
 
     @Test(expected = IndexOutOfBoundsException.class)


### PR DESCRIPTION
…which was allowing an index out of bounds exception to occur.