### PR TITLE
 Fix variant FW generation bugs with enum kind and ofType

### DIFF
--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt16FW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt16FW.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.reaktor.internal.test.types.Flyweight;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt16;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt16FW;
+
+public final class VariantEnumKindOfInt16FW extends Flyweight
+{
+    public static final EnumWithInt16 KIND_ZERO = EnumWithInt16.ONE;
+
+    private static final int FIELD_VALUE_ZERO = 0;
+
+    public static final EnumWithInt16 KIND_INT8 = EnumWithInt16.TWO;
+
+    private static final int FIELD_SIZE_INT8 = BitUtil.SIZE_OF_BYTE;
+
+    private static final int BIT_MASK_INT8 = -256;
+
+    public static final EnumWithInt16 KIND_INT16 = EnumWithInt16.THREE;
+
+    private static final int FIELD_SIZE_INT16 = BitUtil.SIZE_OF_SHORT;
+
+    private static final int BIT_MASK_INT16 = -65536;
+
+    private final EnumWithInt16FW enumWithInt16RO = new EnumWithInt16FW();
+
+    public int getAsZero()
+    {
+        return FIELD_VALUE_ZERO;
+    }
+
+    public int getAsInt8()
+    {
+        return buffer().getByte(enumWithInt16RO.limit());
+    }
+
+    public int getAsInt16()
+    {
+        return buffer().getShort(enumWithInt16RO.limit());
+    }
+
+    public EnumWithInt16 kind()
+    {
+        return enumWithInt16RO.get();
+    }
+
+    public int get()
+    {
+        switch (kind())
+        {
+        case ONE:
+            return getAsZero();
+        case TWO:
+            return getAsInt8();
+        case THREE:
+            return getAsInt16();
+        default:
+            throw new IllegalStateException("Unrecognized kind: " + kind());
+        }
+    }
+
+    @Override
+    public VariantEnumKindOfInt16FW tryWrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        if (null == super.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        if (null == enumWithInt16RO.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        switch (kind())
+        {
+        case ONE:
+            break;
+        case TWO:
+            break;
+        case THREE:
+            break;
+        default:
+            break;
+        }
+        if (limit() > maxLimit)
+        {
+            return null;
+        }
+        return this;
+    }
+
+    @Override
+    public VariantEnumKindOfInt16FW wrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+        enumWithInt16RO.wrap(buffer, offset, maxLimit);
+        switch (kind())
+        {
+        case ONE:
+            break;
+        case TWO:
+            break;
+        case THREE:
+            break;
+        default:
+            break;
+        }
+        checkLimit(limit(), maxLimit);
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        switch (kind())
+        {
+        case ONE:
+            return String.format("VARIANTENUMKINDOFINT16 [zero=%d]", getAsZero());
+        case TWO:
+            return String.format("VARIANTENUMKINDOFINT16 [int8=%d]", getAsInt8());
+        case THREE:
+            return String.format("VARIANTENUMKINDOFINT16 [int16=%d]", getAsInt16());
+        default:
+            return String.format("VARIANTENUMKINDOFINT16 [unknown]");
+        }
+    }
+
+    @Override
+    public int limit()
+    {
+        switch (kind())
+        {
+        case ONE:
+            return enumWithInt16RO.limit();
+        case TWO:
+            return enumWithInt16RO.limit() + FIELD_SIZE_INT8;
+        case THREE:
+            return enumWithInt16RO.limit() + FIELD_SIZE_INT16;
+        default:
+            return enumWithInt16RO.limit();
+        }
+    }
+
+    public static final class Builder extends Flyweight.Builder<VariantEnumKindOfInt16FW>
+    {
+        private final EnumWithInt16FW.Builder enumWithInt16RW = new EnumWithInt16FW.Builder();
+
+        public Builder()
+        {
+            super(new VariantEnumKindOfInt16FW());
+        }
+
+        private Builder kind(
+            EnumWithInt16 value)
+        {
+            enumWithInt16RW.wrap(buffer(), offset(), maxLimit());
+            enumWithInt16RW.set(value);
+            limit(enumWithInt16RW.build().limit());
+            return this;
+        }
+
+        public Builder setAsZero()
+        {
+            kind(KIND_ZERO);
+            return this;
+        }
+
+        public Builder setAsInt8(
+            int value)
+        {
+            kind(KIND_INT8);
+            int newLimit = limit() + FIELD_SIZE_INT8;
+            checkLimit(newLimit, maxLimit());
+            buffer().putByte(limit(), (byte) value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder setAsInt16(
+            int value)
+        {
+            kind(KIND_INT16);
+            int newLimit = limit() + FIELD_SIZE_INT16;
+            checkLimit(newLimit, maxLimit());
+            buffer().putShort(limit(), (short) value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder set(
+            int value)
+        {
+            int highestByteIndex = (Integer.numberOfTrailingZeros(Integer.highestOneBit(value)) + 1)  >> 3;
+            switch (highestByteIndex)
+            {
+            case 0:
+                setAsInt8(value);
+                break;
+            case 1:
+                setAsInt16(value);
+                break;
+            case 4:
+                if (value == 0)
+                {
+                    setAsZero();
+                }
+                else if ((value & BIT_MASK_INT8) == value)
+                {
+                    setAsInt8(value);
+                }
+                else
+                {
+                    setAsInt16(value);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal value: " + value);
+            }
+            return this;
+        }
+
+        public Builder wrap(
+            MutableDirectBuffer buffer,
+            int offset,
+            int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt16FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt16FWTest.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt16;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfInt16FW;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.agrona.BitUtil.SIZE_OF_SHORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class VariantEnumKindOfInt16FWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final VariantEnumKindOfInt16FW.Builder flyweightRW = new VariantEnumKindOfInt16FW.Builder();
+    private final VariantEnumKindOfInt16FW flyweightRO = new VariantEnumKindOfInt16FW();
+
+    static int setAllTestValues(
+        MutableDirectBuffer buffer,
+        final int offset)
+    {
+        int pos = offset;
+        buffer.putShort(pos, EnumWithInt16.THREE.value());
+        buffer.putShort(pos += SIZE_OF_SHORT, (short) 30000);
+        return pos - offset + SIZE_OF_SHORT;
+    }
+
+    @Test
+    public void shouldNotTryWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            assertNull(flyweightRO.tryWrap(buffer,  10, maxLimit));
+        }
+    }
+
+    @Test
+    public void shouldNotWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            try
+            {
+                flyweightRO.wrap(buffer,  10, maxLimit);
+                fail("Exception not thrown");
+            }
+            catch(Exception e)
+            {
+                if (!(e instanceof IndexOutOfBoundsException))
+                {
+                    fail("Unexpected exception " + e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldTryWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.tryWrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.wrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldTryWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
+        assertEquals(30000, flyweightRO.getAsInt16());
+        assertEquals(30000, flyweightRO.get());
+        assertEquals(EnumWithInt16.THREE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        flyweightRO.wrap(buffer, offset, buffer.capacity());
+        assertEquals(30000, flyweightRO.getAsInt16());
+        assertEquals(30000, flyweightRO.get());
+        assertEquals(EnumWithInt16.THREE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsInt8()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsInt8(100)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(100, flyweightRO.getAsInt8());
+        assertEquals(100, flyweightRO.get());
+        assertEquals(EnumWithInt16.TWO, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsInt16()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsInt16(30000)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(30000, flyweightRO.getAsInt16());
+        assertEquals(30000, flyweightRO.get());
+        assertEquals(EnumWithInt16.THREE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsZero()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsZero()
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithInt16.ONE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetInt8UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(100)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(100, flyweightRO.getAsInt8());
+        assertEquals(100, flyweightRO.get());
+        assertEquals(EnumWithInt16.TWO, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetInt16UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(30000)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(30000, flyweightRO.getAsInt16());
+        assertEquals(30000, flyweightRO.get());
+        assertEquals(EnumWithInt16.THREE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetZeroUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(0)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithInt16.ONE, flyweightRO.kind());
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt8FW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt8FW.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.reaktor.internal.test.types.Flyweight;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt8;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt8FW;
+
+public final class VariantEnumKindOfInt8FW extends Flyweight
+{
+    public static final EnumWithInt8 KIND_INT8 = EnumWithInt8.ONE;
+
+    private static final int FIELD_SIZE_INT8 = BitUtil.SIZE_OF_BYTE;
+
+    private static final int BIT_MASK_INT8 = -256;
+
+    public static final EnumWithInt8 KIND_ZERO = EnumWithInt8.TWO;
+
+    private static final int FIELD_VALUE_ZERO = 0;
+
+    public static final EnumWithInt8 KIND_ONE = EnumWithInt8.THREE;
+
+    private static final int FIELD_VALUE_ONE = 1;
+
+    private final EnumWithInt8FW enumWithInt8RO = new EnumWithInt8FW();
+
+    public int getAsInt8()
+    {
+        return buffer().getByte(enumWithInt8RO.limit());
+    }
+
+    public int getAsZero()
+    {
+        return FIELD_VALUE_ZERO;
+    }
+
+    public int getAsOne()
+    {
+        return FIELD_VALUE_ONE;
+    }
+
+    public EnumWithInt8 kind()
+    {
+        return enumWithInt8RO.get();
+    }
+
+    public int get()
+    {
+        switch (kind())
+        {
+        case ONE:
+            return getAsInt8();
+        case TWO:
+            return getAsZero();
+        case THREE:
+            return getAsOne();
+        default:
+            throw new IllegalStateException("Unrecognized kind: " + kind());
+        }
+    }
+
+    @Override
+    public VariantEnumKindOfInt8FW tryWrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        if (null == super.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        if (null == enumWithInt8RO.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        switch (kind())
+        {
+        case ONE:
+            break;
+        case TWO:
+            break;
+        case THREE:
+            break;
+        default:
+            break;
+        }
+        if (limit() > maxLimit)
+        {
+            return null;
+        }
+        return this;
+    }
+
+    @Override
+    public VariantEnumKindOfInt8FW wrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+        enumWithInt8RO.wrap(buffer, offset, maxLimit);
+        switch (kind())
+        {
+        case ONE:
+            break;
+        case TWO:
+            break;
+        case THREE:
+            break;
+        default:
+            break;
+        }
+        checkLimit(limit(), maxLimit);
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        switch (kind())
+        {
+        case ONE:
+            return String.format("VARIANTENUMKINDOFINT8 [int8=%d]", getAsInt8());
+        case TWO:
+            return String.format("VARIANTENUMKINDOFINT8 [zero=%d]", getAsZero());
+        case THREE:
+            return String.format("VARIANTENUMKINDOFINT8 [one=%d]", getAsOne());
+        default:
+            return String.format("VARIANTENUMKINDOFINT8 [unknown]");
+        }
+    }
+
+    @Override
+    public int limit()
+    {
+        switch (kind())
+        {
+        case ONE:
+            return enumWithInt8RO.limit() + FIELD_SIZE_INT8;
+        case TWO:
+            return enumWithInt8RO.limit();
+        case THREE:
+            return enumWithInt8RO.limit();
+        default:
+            return enumWithInt8RO.limit();
+        }
+    }
+
+    public static final class Builder extends Flyweight.Builder<VariantEnumKindOfInt8FW>
+    {
+        private final EnumWithInt8FW.Builder enumWithInt8RW = new EnumWithInt8FW.Builder();
+
+        public Builder()
+        {
+            super(new VariantEnumKindOfInt8FW());
+        }
+
+        private Builder kind(
+            EnumWithInt8 value)
+        {
+            enumWithInt8RW.wrap(buffer(), offset(), maxLimit());
+            enumWithInt8RW.set(value);
+            limit(enumWithInt8RW.build().limit());
+            return this;
+        }
+
+        public Builder setAsInt8(
+            int value)
+        {
+            kind(KIND_INT8);
+            int newLimit = limit() + FIELD_SIZE_INT8;
+            checkLimit(newLimit, maxLimit());
+            buffer().putByte(limit(), (byte) value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder setAsZero()
+        {
+            kind(KIND_ZERO);
+            return this;
+        }
+
+        public Builder setAsOne()
+        {
+            kind(KIND_ONE);
+            return this;
+        }
+
+        public Builder set(int value)
+        {
+            int highestByteIndex = (Integer.numberOfTrailingZeros(Integer.highestOneBit(value)) + 1)  >> 3;
+            switch (highestByteIndex)
+            {
+            case 0:
+                switch (value)
+                {
+                case 1:
+                    setAsOne();
+                    break;
+                default:
+                    setAsInt8(value);
+                    break;
+                }
+                break;
+            case 4:
+                if (value == 0)
+                {
+                    setAsZero();
+                }
+                else
+                {
+                    setAsInt8(value);
+                }
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal value: " + value);
+            }
+            return this;
+        }
+
+        public Builder wrap(
+            MutableDirectBuffer buffer,
+            int offset,
+            int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt8FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfInt8FWTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt8;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfInt8FW;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.agrona.BitUtil.SIZE_OF_BYTE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class VariantEnumKindOfInt8FWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final VariantEnumKindOfInt8FW.Builder flyweightRW = new VariantEnumKindOfInt8FW.Builder();
+    private final VariantEnumKindOfInt8FW flyweightRO = new VariantEnumKindOfInt8FW();
+
+    static int setAllTestValues(
+        MutableDirectBuffer buffer,
+        final int offset)
+    {
+        int pos = offset;
+        buffer.putByte(pos, (byte) 1);
+        buffer.putByte(pos += 1, (byte) 120);
+        return pos - offset + SIZE_OF_BYTE;
+    }
+
+    @Test
+    public void shouldNotTryWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            assertNull(flyweightRO.tryWrap(buffer,  10, maxLimit));
+        }
+    }
+
+    @Test
+    public void shouldNotWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            try
+            {
+                flyweightRO.wrap(buffer,  10, maxLimit);
+                fail("Exception not thrown");
+            }
+            catch(Exception e)
+            {
+                if (!(e instanceof IndexOutOfBoundsException))
+                {
+                    fail("Unexpected exception " + e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldTryWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.tryWrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.wrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldTryWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
+        assertEquals(120, flyweightRO.getAsInt8());
+        assertEquals(120, flyweightRO.get());
+        assertEquals(EnumWithInt8.ONE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        flyweightRO.wrap(buffer, offset, buffer.capacity());
+        assertEquals(120, flyweightRO.getAsInt8());
+        assertEquals(120, flyweightRO.get());
+        assertEquals(EnumWithInt8.ONE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsInt8()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsInt8(100)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(100, flyweightRO.getAsInt8());
+        assertEquals(100, flyweightRO.get());
+        assertEquals(EnumWithInt8.ONE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetInt8UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(100)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(100, flyweightRO.getAsInt8());
+        assertEquals(100, flyweightRO.get());
+        assertEquals(EnumWithInt8.ONE, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetZeroUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(0)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithInt8.TWO, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetOneUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(1)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(1, flyweightRO.getAsOne());
+        assertEquals(1, flyweightRO.get());
+        assertEquals(EnumWithInt8.THREE, flyweightRO.kind());
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint16FW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint16FW.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.reaktor.internal.test.types.Flyweight;
+
+public final class VariantEnumKindOfUint16FW extends Flyweight
+{
+    public static final EnumWithUint16 KIND_UINT16 = EnumWithUint16.ICHI;
+
+    private static final int FIELD_SIZE_UINT16 = BitUtil.SIZE_OF_INT;
+
+    public static final EnumWithUint16 KIND_UINT8 = EnumWithUint16.NI;
+
+    private static final int FIELD_SIZE_UINT8 = BitUtil.SIZE_OF_SHORT;
+
+    public static final EnumWithUint16 KIND_ZERO = EnumWithUint16.SAN;
+
+    private static final int FIELD_VALUE_ZERO = 0;
+
+    private final EnumWithUint16FW enumWithUint16RO = new EnumWithUint16FW();
+
+    public int getAsUint16()
+    {
+        return buffer().getInt(enumWithUint16RO.limit());
+    }
+
+    public int getAsUint8()
+    {
+        return buffer().getShort(enumWithUint16RO.limit());
+    }
+
+    public int getAsZero()
+    {
+        return FIELD_VALUE_ZERO;
+    }
+
+    public EnumWithUint16 kind()
+    {
+        return enumWithUint16RO.get();
+    }
+
+    public int get()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return getAsUint16();
+        case NI:
+            return getAsUint8();
+        case SAN:
+            return getAsZero();
+        default:
+            throw new IllegalStateException("Unrecognized kind: " + kind());
+        }
+    }
+
+    @Override
+    public VariantEnumKindOfUint16FW tryWrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        if (null == super.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        if (null == enumWithUint16RO.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        switch (kind())
+        {
+        case ICHI:
+            break;
+        case NI:
+            break;
+        case SAN:
+            break;
+        default:
+            break;
+        }
+        if (limit() > maxLimit)
+        {
+            return null;
+        }
+        return this;
+    }
+
+    @Override
+    public VariantEnumKindOfUint16FW wrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+        enumWithUint16RO.wrap(buffer, offset, maxLimit);
+        switch (kind())
+        {
+        case ICHI:
+            break;
+        case NI:
+            break;
+        case SAN:
+            break;
+        default:
+            break;
+        }
+        checkLimit(limit(), maxLimit);
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return String.format("VARIANTENUMKINDOFUINT16 [uint16=%d]", getAsUint16());
+        case NI:
+            return String.format("VARIANTENUMKINDOFUINT16 [uint8=%d]", getAsUint8());
+        case SAN:
+            return String.format("VARIANTENUMKINDOFUINT16 [zero=%d]", getAsZero());
+        default:
+            return String.format("VARIANTENUMKINDOFUINT16 [unknown]");
+        }
+    }
+
+    @Override
+    public int limit()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return enumWithUint16RO.limit() + FIELD_SIZE_UINT16;
+        case NI:
+            return enumWithUint16RO.limit() + FIELD_SIZE_UINT8;
+        case SAN:
+            return enumWithUint16RO.limit();
+        default:
+            return enumWithUint16RO.limit();
+        }
+    }
+
+    public static final class Builder extends Flyweight.Builder<VariantEnumKindOfUint16FW>
+    {
+        private final EnumWithUint16FW.Builder enumWithUint16RW = new EnumWithUint16FW.Builder();
+
+        public Builder()
+        {
+            super(new VariantEnumKindOfUint16FW());
+        }
+
+        private Builder kind(
+            EnumWithUint16 value)
+        {
+            enumWithUint16RW.wrap(buffer(), offset(), maxLimit());
+            enumWithUint16RW.set(value);
+            limit(enumWithUint16RW.build().limit());
+            return this;
+        }
+
+        public Builder setAsUint16(
+            int value)
+        {
+            kind(KIND_UINT16);
+            int newLimit = limit() + FIELD_SIZE_UINT16;
+            checkLimit(newLimit, maxLimit());
+            buffer().putInt(limit(), value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder setAsUint8(
+            int value)
+        {
+            kind(KIND_UINT8);
+            int newLimit = limit() + FIELD_SIZE_UINT8;
+            checkLimit(newLimit, maxLimit());
+            buffer().putShort(limit(), (short) value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder setAsZero()
+        {
+            kind(KIND_ZERO);
+            return this;
+        }
+
+        public Builder set(
+            int value)
+        {
+            int highestByteIndex = Integer.numberOfTrailingZeros(Integer.highestOneBit(value)) >> 3;
+            switch (highestByteIndex)
+            {
+            case 0:
+                setAsUint8(value);
+                break;
+            case 1:
+                setAsUint16(value);
+                break;
+            case 4:
+                setAsZero();
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal value: " + value);
+            }
+            return this;
+        }
+
+        public Builder wrap(
+            MutableDirectBuffer buffer,
+            int offset,
+            int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint16FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint16FWTest.java
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint16;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint16FW;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.agrona.BitUtil.SIZE_OF_INT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class VariantEnumKindOfUint16FWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final VariantEnumKindOfUint16FW.Builder flyweightRW = new VariantEnumKindOfUint16FW.Builder();
+    private final VariantEnumKindOfUint16FW flyweightRO = new VariantEnumKindOfUint16FW();
+
+    static int setAllTestValues(
+        MutableDirectBuffer buffer,
+        final int offset)
+    {
+        int pos = offset;
+        buffer.putInt(pos, EnumWithUint16.ICHI.value());
+        buffer.putInt(pos += SIZE_OF_INT, 60000);
+        return pos - offset + SIZE_OF_INT;
+    }
+
+    @Test
+    public void shouldNotTryWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            assertNull(flyweightRO.tryWrap(buffer,  10, maxLimit));
+        }
+    }
+
+    @Test
+    public void shouldNotWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            try
+            {
+                flyweightRO.wrap(buffer,  10, maxLimit);
+                fail("Exception not thrown");
+            }
+            catch(Exception e)
+            {
+                if (!(e instanceof IndexOutOfBoundsException))
+                {
+                    fail("Unexpected exception " + e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldTryWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.tryWrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.wrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldTryWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
+        assertEquals(60000, flyweightRO.getAsUint16());
+        assertEquals(60000, flyweightRO.get());
+        assertEquals(EnumWithUint16.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        flyweightRO.wrap(buffer, offset, buffer.capacity());
+        assertEquals(60000, flyweightRO.getAsUint16());
+        assertEquals(60000, flyweightRO.get());
+        assertEquals(EnumWithUint16.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsUint8()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsUint8(200)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(200, flyweightRO.getAsUint8());
+        assertEquals(200, flyweightRO.get());
+        assertEquals(EnumWithUint16.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsUint16()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsUint16(60000)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(60000, flyweightRO.getAsUint16());
+        assertEquals(60000, flyweightRO.get());
+        assertEquals(EnumWithUint16.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsZero()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsZero()
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithUint16.SAN, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetUint8UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(200)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(200, flyweightRO.getAsUint8());
+        assertEquals(200, flyweightRO.get());
+        assertEquals(EnumWithUint16.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetUint16UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(60000)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(60000, flyweightRO.getAsUint16());
+        assertEquals(60000, flyweightRO.get());
+        assertEquals(EnumWithUint16.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetZeroUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(0)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithUint16.SAN, flyweightRO.kind());
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint32FW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint32FW.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.reaktor.internal.test.types.Flyweight;
+
+public final class VariantEnumKindOfUint32FW extends Flyweight
+{
+    public static final EnumWithUint32 KIND_ZERO = EnumWithUint32.ICHI;
+
+    private static final int FIELD_VALUE_ZERO = 0;
+
+    public static final EnumWithUint32 KIND_UINT32 = EnumWithUint32.NI;
+
+    private static final int FIELD_SIZE_UINT32 = BitUtil.SIZE_OF_LONG;
+
+    public static final EnumWithUint32 KIND_ONE = EnumWithUint32.SAN;
+
+    private static final int FIELD_VALUE_ONE = 1;
+
+    private final EnumWithUint32FW enumWithUint32RO = new EnumWithUint32FW();
+
+    public int getAsZero()
+    {
+        return FIELD_VALUE_ZERO;
+    }
+
+    public long getAsUint32()
+    {
+        return buffer().getLong(enumWithUint32RO.limit());
+    }
+
+    public int getAsOne()
+    {
+        return FIELD_VALUE_ONE;
+    }
+
+    public EnumWithUint32 kind()
+    {
+        return enumWithUint32RO.get();
+    }
+
+    public long get()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return getAsZero();
+        case NI:
+            return getAsUint32();
+        case SAN:
+            return getAsOne();
+        default:
+            throw new IllegalStateException("Unrecognized kind: " + kind());
+        }
+    }
+
+    @Override
+    public VariantEnumKindOfUint32FW tryWrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        if (null == super.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        if (null == enumWithUint32RO.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        switch (kind())
+        {
+        case ICHI:
+            break;
+        case NI:
+            break;
+        case SAN:
+            break;
+        default:
+            break;
+        }
+        if (limit() > maxLimit)
+        {
+            return null;
+        }
+        return this;
+    }
+
+    @Override
+    public VariantEnumKindOfUint32FW wrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+        enumWithUint32RO.wrap(buffer, offset, maxLimit);
+        switch (kind())
+        {
+        case ICHI:
+            break;
+        case NI:
+            break;
+        case SAN:
+            break;
+        default:
+            break;
+        }
+        checkLimit(limit(), maxLimit);
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return String.format("VARIANTENUMKINDOFUINT32 [zero=%d]", getAsZero());
+        case NI:
+            return String.format("VARIANTENUMKINDOFUINT32 [uint32=%d]", getAsUint32());
+        case SAN:
+            return String.format("VARIANTENUMKINDOFUINT32 [one=%d]", getAsOne());
+        default:
+            return String.format("VARIANTENUMKINDOFUINT32 [unknown]");
+        }
+    }
+
+    @Override
+    public int limit()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return enumWithUint32RO.limit();
+        case NI:
+            return enumWithUint32RO.limit() + FIELD_SIZE_UINT32;
+        case SAN:
+            return enumWithUint32RO.limit();
+        default:
+            return enumWithUint32RO.limit();
+        }
+    }
+
+    public static final class Builder extends Flyweight.Builder<VariantEnumKindOfUint32FW>
+    {
+        private final EnumWithUint32FW.Builder enumWithUint32RW = new EnumWithUint32FW.Builder();
+
+        public Builder()
+        {
+            super(new VariantEnumKindOfUint32FW());
+        }
+
+        private Builder kind(
+            EnumWithUint32 value)
+        {
+            enumWithUint32RW.wrap(buffer(), offset(), maxLimit());
+            enumWithUint32RW.set(value);
+            limit(enumWithUint32RW.build().limit());
+            return this;
+        }
+
+        public Builder setAsZero()
+        {
+            kind(KIND_ZERO);
+            return this;
+        }
+
+        public Builder setAsUint32(
+            long value)
+        {
+            kind(KIND_UINT32);
+            int newLimit = limit() + FIELD_SIZE_UINT32;
+            checkLimit(newLimit, maxLimit());
+            buffer().putLong(limit(), value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder setAsOne()
+        {
+            kind(KIND_ONE);
+            return this;
+        }
+
+        public Builder set(
+            long value)
+        {
+            int highestByteIndex = Long.numberOfTrailingZeros(Long.highestOneBit(value)) >> 3;
+            switch (highestByteIndex)
+            {
+            case 0:
+                switch ((int) value)
+                {
+                case 1:
+                    setAsOne();
+                    break;
+                }
+                break;
+            case 2:
+            case 3:
+                setAsUint32(value);
+                break;
+            case 8:
+                setAsZero();
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal value: " + value);
+            }
+            return this;
+        }
+
+        public Builder wrap(
+            MutableDirectBuffer buffer,
+            int offset,
+            int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint32FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint32FWTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint32;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint32FW;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.agrona.BitUtil.SIZE_OF_LONG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class VariantEnumKindOfUint32FWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final VariantEnumKindOfUint32FW.Builder flyweightRW = new VariantEnumKindOfUint32FW.Builder();
+    private final VariantEnumKindOfUint32FW flyweightRO = new VariantEnumKindOfUint32FW();
+
+    static int setAllTestValues(
+        MutableDirectBuffer buffer,
+        final int offset)
+    {
+        int pos = offset;
+        buffer.putLong(pos, EnumWithUint32.NI.value());
+        buffer.putLong(pos += SIZE_OF_LONG, 4000000000L);
+        return pos - offset + SIZE_OF_LONG;
+    }
+
+    @Test
+    public void shouldNotTryWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            assertNull(flyweightRO.tryWrap(buffer,  10, maxLimit));
+        }
+    }
+
+    @Test
+    public void shouldNotWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            try
+            {
+                flyweightRO.wrap(buffer,  10, maxLimit);
+                fail("Exception not thrown");
+            }
+            catch(Exception e)
+            {
+                if (!(e instanceof IndexOutOfBoundsException))
+                {
+                    fail("Unexpected exception " + e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldTryWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.tryWrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.wrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldTryWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
+        assertEquals(4000000000L, flyweightRO.getAsUint32());
+        assertEquals(4000000000L, flyweightRO.get());
+        assertEquals(EnumWithUint32.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        flyweightRO.wrap(buffer, offset, buffer.capacity());
+        assertEquals(4000000000L, flyweightRO.getAsUint32());
+        assertEquals(4000000000L, flyweightRO.get());
+        assertEquals(EnumWithUint32.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsUint32()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsUint32(4000000000L)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(4000000000L, flyweightRO.getAsUint32());
+        assertEquals(4000000000L, flyweightRO.get());
+        assertEquals(EnumWithUint32.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetUint32UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(4000000000L)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(4000000000L, flyweightRO.getAsUint32());
+        assertEquals(4000000000L, flyweightRO.get());
+        assertEquals(EnumWithUint32.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetZeroUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(0)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithUint32.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetOneUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(1)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(1, flyweightRO.getAsOne());
+        assertEquals(1, flyweightRO.get());
+        assertEquals(EnumWithUint32.SAN, flyweightRO.kind());
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint8FW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint8FW.java
@@ -1,0 +1,237 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.reaktor.internal.test.types.Flyweight;
+
+public final class VariantEnumKindOfUint8FW extends Flyweight
+{
+    public static final EnumWithUint8 KIND_UINT8 = EnumWithUint8.ICHI;
+
+    private static final int FIELD_SIZE_UINT8 = BitUtil.SIZE_OF_SHORT;
+
+    public static final EnumWithUint8 KIND_ZERO = EnumWithUint8.NI;
+
+    private static final int FIELD_VALUE_ZERO = 0;
+
+    public static final EnumWithUint8 KIND_ONE = EnumWithUint8.SAN;
+
+    private static final int FIELD_VALUE_ONE = 1;
+
+    private final EnumWithUint8FW enumWithUint8RO = new EnumWithUint8FW();
+
+    public int getAsUint8()
+    {
+        return buffer().getShort(enumWithUint8RO.limit());
+    }
+
+    public int getAsZero()
+    {
+        return FIELD_VALUE_ZERO;
+    }
+
+    public int getAsOne()
+    {
+        return FIELD_VALUE_ONE;
+    }
+
+    public EnumWithUint8 kind()
+    {
+        return enumWithUint8RO.get();
+    }
+
+    public int get()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return getAsUint8();
+        case NI:
+            return getAsZero();
+        case SAN:
+            return getAsOne();
+        default:
+            throw new IllegalStateException("Unrecognized kind: " + kind());
+        }
+    }
+
+    @Override
+    public VariantEnumKindOfUint8FW tryWrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        if (null == super.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        if (null == enumWithUint8RO.tryWrap(buffer, offset, maxLimit))
+        {
+            return null;
+        }
+        switch (kind())
+        {
+        case ICHI:
+            break;
+        case NI:
+            break;
+        case SAN:
+            break;
+        default:
+            break;
+        }
+        if (limit() > maxLimit)
+        {
+            return null;
+        }
+        return this;
+    }
+
+    @Override
+    public VariantEnumKindOfUint8FW wrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+        enumWithUint8RO.wrap(buffer, offset, maxLimit);
+        switch (kind())
+        {
+        case ICHI:
+            break;
+        case NI:
+            break;
+        case SAN:
+            break;
+        default:
+            break;
+        }
+        checkLimit(limit(), maxLimit);
+        return this;
+    }
+
+    @Override
+    public String toString()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return String.format("VARIANTENUMKINDOFUINT8 [uint8=%d]", getAsUint8());
+        case NI:
+            return String.format("VARIANTENUMKINDOFUINT8 [zero=%d]", getAsZero());
+        case SAN:
+            return String.format("VARIANTENUMKINDOFUINT8 [one=%d]", getAsOne());
+        default:
+            return String.format("VARIANTENUMKINDOFUINT8 [unknown]");
+        }
+    }
+
+    @Override
+    public int limit()
+    {
+        switch (kind())
+        {
+        case ICHI:
+            return enumWithUint8RO.limit() + FIELD_SIZE_UINT8;
+        case NI:
+            return enumWithUint8RO.limit();
+        case SAN:
+            return enumWithUint8RO.limit();
+        default:
+            return enumWithUint8RO.limit();
+        }
+    }
+
+    public static final class Builder extends Flyweight.Builder<VariantEnumKindOfUint8FW>
+    {
+        private final EnumWithUint8FW.Builder enumWithUint8RW = new EnumWithUint8FW.Builder();
+
+        public Builder()
+        {
+            super(new VariantEnumKindOfUint8FW());
+        }
+
+        private Builder kind(
+            EnumWithUint8 value)
+        {
+            enumWithUint8RW.wrap(buffer(), offset(), maxLimit());
+            enumWithUint8RW.set(value);
+            limit(enumWithUint8RW.build().limit());
+            return this;
+        }
+
+        public Builder setAsUint8(
+            int value)
+        {
+            kind(KIND_UINT8);
+            int newLimit = limit() + FIELD_SIZE_UINT8;
+            checkLimit(newLimit, maxLimit());
+            buffer().putShort(limit(), (short) value);
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder setAsZero()
+        {
+            kind(KIND_ZERO);
+            return this;
+        }
+
+        public Builder setAsOne()
+        {
+            kind(KIND_ONE);
+            return this;
+        }
+
+        public Builder set(
+            int value)
+        {
+            int highestByteIndex = Integer.numberOfTrailingZeros(Integer.highestOneBit(value)) >> 3;
+            switch (highestByteIndex)
+            {
+            case 0:
+                switch (value)
+                {
+                case 1:
+                    setAsOne();
+                    break;
+                default:
+                    setAsUint8(value);
+                    break;
+                }
+                break;
+            case 4:
+                setAsZero();
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal value: " + value);
+            }
+            return this;
+        }
+
+        public Builder wrap(
+            MutableDirectBuffer buffer,
+            int offset,
+            int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            return this;
+        }
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint8FWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/VariantEnumKindOfUint8FWTest.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint8;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint8FW;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.agrona.BitUtil.SIZE_OF_SHORT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class VariantEnumKindOfUint8FWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final MutableDirectBuffer expected = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+
+    private final VariantEnumKindOfUint8FW.Builder flyweightRW = new VariantEnumKindOfUint8FW.Builder();
+    private final VariantEnumKindOfUint8FW flyweightRO = new VariantEnumKindOfUint8FW();
+
+    static int setAllTestValues(
+        MutableDirectBuffer buffer,
+        final int offset)
+    {
+        int pos = offset;
+        buffer.putShort(pos, EnumWithUint8.ICHI.value());
+        buffer.putShort(pos += SIZE_OF_SHORT, (short) 200);
+        return pos - offset + SIZE_OF_SHORT;
+    }
+
+    @Test
+    public void shouldNotTryWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            assertNull(flyweightRO.tryWrap(buffer,  10, maxLimit));
+        }
+    }
+
+    @Test
+    public void shouldNotWrapWhenIncomplete()
+    {
+        int size = setAllTestValues(buffer, 10);
+        for (int maxLimit=10; maxLimit < 10 + size; maxLimit++)
+        {
+            try
+            {
+                flyweightRO.wrap(buffer,  10, maxLimit);
+                fail("Exception not thrown");
+            }
+            catch(Exception e)
+            {
+                if (!(e instanceof IndexOutOfBoundsException))
+                {
+                    fail("Unexpected exception " + e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldTryWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.tryWrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldWrapWhenLengthSufficientCase()
+    {
+        int size = setAllTestValues(buffer, 10);
+        assertSame(flyweightRO, flyweightRO.wrap(buffer, 10, 10 + size));
+    }
+
+    @Test
+    public void shouldTryWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        assertNotNull(flyweightRO.tryWrap(buffer, offset, buffer.capacity()));
+        assertEquals(200, flyweightRO.getAsUint8());
+        assertEquals(200, flyweightRO.get());
+        assertEquals(EnumWithUint8.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldWrapAndReadAllValuesCase() throws Exception
+    {
+        final int offset = 1;
+        setAllTestValues(buffer, offset);
+        flyweightRO.wrap(buffer, offset, buffer.capacity());
+        assertEquals(200, flyweightRO.getAsUint8());
+        assertEquals(200, flyweightRO.get());
+        assertEquals(EnumWithUint8.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetAsUint8()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .setAsUint8(200)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(200, flyweightRO.getAsUint8());
+        assertEquals(200, flyweightRO.get());
+        assertEquals(EnumWithUint8.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetInt8UsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(200)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(200, flyweightRO.getAsUint8());
+        assertEquals(200, flyweightRO.get());
+        assertEquals(EnumWithUint8.ICHI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetZeroUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(0)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(0, flyweightRO.getAsZero());
+        assertEquals(0, flyweightRO.get());
+        assertEquals(EnumWithUint8.NI, flyweightRO.kind());
+    }
+
+    @Test
+    public void shouldSetOneUsingSet()
+    {
+        int limit = flyweightRW.wrap(buffer, 0, buffer.capacity())
+            .set(1)
+            .build()
+            .limit();
+        flyweightRO.wrap(buffer, 0, limit);
+        assertEquals(1, flyweightRO.getAsOne());
+        assertEquals(1, flyweightRO.get());
+        assertEquals(EnumWithUint8.SAN, flyweightRO.kind());
+    }
+}

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -275,5 +275,40 @@ scope test
             case TWO: string16;
             case THREE: string32;
         }
+
+        variant VariantEnumKindOfInt8 switch (EnumWithInt8) of int8
+        {
+            case ONE: int8;
+            case TWO: 0;
+            case THREE: 1;
+        }
+
+        variant VariantEnumKindOfInt16 switch (EnumWithInt16) of int16
+        {
+            case ONE: 0;
+            case TWO: int8;
+            case THREE: int16;
+        }
+
+        variant VariantEnumKindOfUint8 switch (EnumWithUint8) of uint8
+        {
+            case ICHI: uint8;
+            case NI: 0;
+            case SAN: 1;
+        }
+
+        variant VariantEnumKindOfUint16 switch (EnumWithUint16) of uint16
+        {
+            case ICHI: uint16;
+            case NI: uint8;
+            case SAN: 0;
+        }
+
+        variant VariantEnumKindOfUint32 switch (EnumWithUint32) of uint32
+        {
+            case ICHI: 0;
+            case NI: uint32;
+            case SAN: 1;
+        }
     }
 }


### PR DESCRIPTION
Fixed:
- Variant FW generation issues when `int8` and `int16` are used
- Variant FW generation issues when `enum` kind is used with constant members

Updated:
- Design of `tryWrap()` method for variant FW

Todo:
- Need to remove manually created FW classes from `generated` directory