### PR TITLE
Design list flyweight with default null byte

### DIFF
--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -269,21 +269,22 @@ public class ListWithDefaultNullFW extends Flyweight
         Object variantOfInt = null;
 
         StringBuilder format = new StringBuilder();
-        format.append("LIST_WITH_DEFAULT_NULL [");
-        format.append("variantOfString1={0}");
+        format.append("LIST_WITH_DEFAULT_NULL [bitmask={0}");
+        format.append(", variantOfString1={1}");
         if ((bitmask & MASK_VARIANT_OF_STRING2) != 0L)
         {
-            format.append(", variantOfString2={1}");
+            format.append(", variantOfString2={2}");
             variantOfString2 = variantOfString2();
         }
-        format.append(", variantOfUint={2}");
+        format.append(", variantOfUint={3}");
         if ((bitmask & MASK_VARIANT_OF_INT) != 0L)
         {
-            format.append(", variantOfInt={3}");
+            format.append(", variantOfInt={4}");
             variantOfInt = variantOfInt();
         }
         format.append("]");
         return MessageFormat.format(format.toString(),
+            String.format("0x%16X", bitmask),
             variantOfString1(),
             variantOfString2,
             variantOfUint(),
@@ -305,25 +306,33 @@ public class ListWithDefaultNullFW extends Flyweight
             super(new ListWithDefaultNullFW());
         }
 
+        private VariantEnumKindWithString32FW.Builder variantOfString1()
+        {
+            assert lastFieldSet < INDEX_VARIANT_OF_STRING1 : "Field \"variantOfString1\" cannot be set out of order";
+            return variantOfString32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
         public Builder variantOfString1(
             String value)
         {
-            assert lastFieldSet < INDEX_VARIANT_OF_STRING1 : "Field \"variantOfString1\" cannot be set out of order";
-            VariantEnumKindWithString32FW.Builder variantOfString1RW = this.variantOfString32RW.wrap(buffer(), limit(),
-                maxLimit());
+            VariantEnumKindWithString32FW.Builder variantOfString1RW = variantOfString1();
             variantOfString1RW.set(value);
             lastFieldSet = INDEX_VARIANT_OF_STRING1;
             limit(variantOfString1RW.build().limit());
             return this;
         }
 
-        public Builder variantOfString2(
-            String value)
+        private VariantEnumKindWithString32FW.Builder variantOfString2()
         {
             assert lastFieldSet < INDEX_VARIANT_OF_STRING2 : "Field \"variantOfString2\" cannot be set out of order";
             assert lastFieldSet == INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
-            VariantEnumKindWithString32FW.Builder variantOfString2RW = this.variantOfString32RW.wrap(buffer(), limit(),
-                maxLimit());
+            return variantOfString32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfString2(
+            String value)
+        {
+            VariantEnumKindWithString32FW.Builder variantOfString2RW = variantOfString2();
             variantOfString2RW.set(value);
             lastFieldSet = INDEX_VARIANT_OF_STRING2;
             limit(variantOfString2RW.build().limit());
@@ -341,15 +350,20 @@ public class ListWithDefaultNullFW extends Flyweight
             return this;
         }
 
-        public Builder variantOfUint(
-            long value)
+        private VariantEnumKindOfUint32FW.Builder variantOfUint()
         {
             assert lastFieldSet < INDEX_VARIANT_OF_UINT : "Field \"variantOfUint\" cannot be set out of order";
             if (lastFieldSet < INDEX_VARIANT_OF_STRING2)
             {
                 defaultVariantOfString2();
             }
-            VariantEnumKindOfUint32FW.Builder variantOfUintRW = this.variantOfUint32RW.wrap(buffer(), limit(), maxLimit());
+            return variantOfUint32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfUint(
+            long value)
+        {
+            VariantEnumKindOfUint32FW.Builder variantOfUintRW = variantOfUint();
             variantOfUintRW.set(value);
             lastFieldSet = INDEX_VARIANT_OF_UINT;
             limit(variantOfUintRW.build().limit());
@@ -370,15 +384,20 @@ public class ListWithDefaultNullFW extends Flyweight
             return this;
         }
 
-        public Builder variantOfInt(
-            int value)
+        private VariantEnumKindWithInt32FW.Builder variantOfInt()
         {
             assert lastFieldSet < INDEX_VARIANT_OF_INT : "Field \"variantOfInt\" cannot be set out of order";
             if (lastFieldSet < INDEX_VARIANT_OF_UINT)
             {
                 defaultVariantOfUint();
             }
-            VariantEnumKindWithInt32FW.Builder variantOfIntRW = this.variantOfInt32RW.wrap(buffer(), limit(), maxLimit());
+            return variantOfInt32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfInt(
+            int value)
+        {
+            VariantEnumKindWithInt32FW.Builder variantOfIntRW = variantOfInt();
             variantOfIntRW.set(value);
             lastFieldSet = INDEX_VARIANT_OF_INT;
             limit(variantOfIntRW.build().limit());

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -107,8 +107,8 @@ public class ListWithDefaultNullFW extends Flyweight
     {
         super.wrap(buffer, offset, maxLimit);
         int fieldLimit = offset + FIRST_FIELD_OFFSET;
-        bitmask = 0;
         final int length = length();
+        bitmask = 0;
         for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
             switch (field)
@@ -171,14 +171,18 @@ public class ListWithDefaultNullFW extends Flyweight
             return null;
         }
         int fieldLimit = offset + FIRST_FIELD_OFFSET;
-        bitmask = 0;
         if (fieldLimit > limit())
         {
             return null;
         }
         final int length = length();
+        bitmask = 0;
         for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
+            if (fieldLimit + SIZE_OF_BYTE > limit())
+            {
+                return null;
+            }
             switch (field)
             {
             case INDEX_VARIANT_OF_STRING1:
@@ -190,10 +194,6 @@ public class ListWithDefaultNullFW extends Flyweight
                 bitmask |= 1 << INDEX_VARIANT_OF_STRING1;
                 break;
             case INDEX_VARIANT_OF_STRING2:
-                if (fieldLimit + SIZE_OF_BYTE > limit())
-                {
-                    return null;
-                }
                 if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfString2RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
@@ -209,10 +209,6 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 break;
             case INDEX_VARIANT_OF_UINT:
-                if (fieldLimit + SIZE_OF_BYTE > limit())
-                {
-                    return null;
-                }
                 if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfUintRO.tryWrap(buffer, fieldLimit, maxLimit) == null)
@@ -228,10 +224,6 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 break;
             case INDEX_VARIANT_OF_INT:
-                if (fieldLimit + SIZE_OF_BYTE > limit())
-                {
-                    return null;
-                }
                 if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfIntRO.tryWrap(buffer, fieldLimit, maxLimit) == null)

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -109,7 +109,6 @@ public class ListWithDefaultNullFW extends Flyweight
         checkLimit(offset + PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE, maxLimit);
         final int limit = limit();
         checkLimit(limit, maxLimit);
-        checkLimit(offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE, limit);
         final int length = length();
         bitmask = 0;
         int fieldLimit = offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE;
@@ -161,6 +160,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 break;
             }
         }
+        checkLimit(fieldLimit, limit);
         return this;
     }
 
@@ -180,10 +180,6 @@ public class ListWithDefaultNullFW extends Flyweight
         }
         final int limit = limit();
         if (limit > maxLimit)
-        {
-            return null;
-        }
-        if (offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE > limit)
         {
             return null;
         }
@@ -253,6 +249,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 break;
             }
         }
+        checkLimit(fieldLimit, limit);
         return this;
     }
 
@@ -284,7 +281,7 @@ public class ListWithDefaultNullFW extends Flyweight
         }
         format.append("]");
         return MessageFormat.format(format.toString(),
-            String.format("0x%16X", bitmask),
+            String.format("0x%16x", bitmask),
             variantOfString1(),
             variantOfString2,
             variantOfUint(),

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -1,0 +1,406 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import static org.agrona.BitUtil.SIZE_OF_BYTE;
+
+import java.text.MessageFormat;
+
+import org.agrona.BitUtil;
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.reaktivity.reaktor.internal.test.types.Flyweight;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint32FW;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindWithInt32FW;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindWithString32FW;
+
+public class ListWithDefaultNullFW extends Flyweight
+{
+    public static final int PHYSICAL_LENGTH_OFFSET = 0;
+
+    private static final int PHYSICAL_LENGTH_SIZE = BitUtil.SIZE_OF_INT;
+
+    public static final int LOGICAL_LENGTH_OFFSET = PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE;
+
+    private static final int LOGICAL_LENGTH_SIZE = BitUtil.SIZE_OF_INT;
+
+    private static final byte DEFAULT_NULL_VALUE = 0x40;
+
+    private static final int FIRST_FIELD_OFFSET = LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE;
+
+    private static final int FIELD_INDEX_VARIANT_OF_STRING1 = 0;
+
+    private static final int FIELD_INDEX_VARIANT_OF_STRING2 = 1;
+
+    private static final int FIELD_INDEX_VARIANT_OF_UINT = 2;
+
+    private static final int FIELD_INDEX_VARIANT_OF_INT = 3;
+
+    private static final long FIELD_DEFAULT_VALUE_VARIANT_OF_UINT = 4000000000L;
+
+    private VariantEnumKindWithString32FW variantOfString1RO = new VariantEnumKindWithString32FW();
+
+    private VariantEnumKindWithString32FW variantOfString2RO = new VariantEnumKindWithString32FW();
+
+    private VariantEnumKindOfUint32FW variantOfUintRO = new VariantEnumKindOfUint32FW();
+
+    private VariantEnumKindWithInt32FW variantOfIntRO = new VariantEnumKindWithInt32FW();
+
+    public int length()
+    {
+        return buffer().getInt(offset() + LOGICAL_LENGTH_OFFSET);
+    }
+
+    public String variantOfString1()
+    {
+        return variantOfString1RO.get();
+    }
+
+    private int fieldLimitVariantOfString1()
+    {
+        return variantOfString1RO.limit();
+    }
+
+    public String variantOfString2()
+    {
+        assert variantOfString2IsSet() : "Field \"variantOfString2\" is not set";
+        return variantOfString2RO.get();
+    }
+
+    private int fieldLimitVariantOfString2()
+    {
+        return variantOfString2IsSet() ? variantOfString2RO.limit() : fieldLimitVariantOfString1() + 1;
+    }
+
+    private boolean variantOfString2IsSet()
+    {
+        return length() > FIELD_INDEX_VARIANT_OF_STRING2 && buffer().getByte(fieldLimitVariantOfString1()) != DEFAULT_NULL_VALUE;
+    }
+
+    public long variantOfUint()
+    {
+        return variantOfUintIsSet() ? variantOfUintRO.get() : FIELD_DEFAULT_VALUE_VARIANT_OF_UINT;
+    }
+
+    private int fieldLimitVariantOfUint()
+    {
+        return variantOfUintIsSet() ? variantOfUintRO.limit() : fieldLimitVariantOfString2() + 1;
+    }
+
+    private boolean variantOfUintIsSet()
+    {
+        return length() > FIELD_INDEX_VARIANT_OF_UINT && buffer().getByte(fieldLimitVariantOfString2()) != DEFAULT_NULL_VALUE;
+    }
+
+    public int variantOfInt()
+    {
+        assert variantOfIntIsSet() : "Field \"variantOfInt\" is not set";
+        return variantOfIntRO.get();
+    }
+
+    private int fieldLimitVariantOfInt()
+    {
+        return variantOfIntIsSet() ? variantOfIntRO.limit() : fieldLimitVariantOfUint() + 1;
+    }
+
+    private boolean variantOfIntIsSet()
+    {
+        return length() > FIELD_INDEX_VARIANT_OF_INT && buffer().getByte(fieldLimitVariantOfUint()) != DEFAULT_NULL_VALUE;
+    }
+
+    @Override
+    public ListWithDefaultNullFW wrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        super.wrap(buffer, offset, maxLimit);
+        int fieldLimit = offset + FIRST_FIELD_OFFSET;
+        final int length = length();
+        for (int field = FIELD_INDEX_VARIANT_OF_STRING1; field < length; field++)
+        {
+            switch (field)
+            {
+            case FIELD_INDEX_VARIANT_OF_STRING1:
+                variantOfString1RO.wrap(buffer, fieldLimit, maxLimit);
+                fieldLimit = variantOfString1RO.limit();
+                break;
+            case FIELD_INDEX_VARIANT_OF_STRING2:
+                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+                {
+                    variantOfString2RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfString2RO.limit();
+                }
+                else
+                {
+                    fieldLimit++;
+                }
+                break;
+            case FIELD_INDEX_VARIANT_OF_UINT:
+                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+                {
+                    variantOfUintRO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfUintRO.limit();
+                }
+                else
+                {
+                    fieldLimit++;
+                }
+                break;
+            case FIELD_INDEX_VARIANT_OF_INT:
+                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+                {
+                    variantOfIntRO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfIntRO.limit();
+                }
+                else
+                {
+                    fieldLimit++;
+                }
+                break;
+            }
+        }
+        checkLimit(limit(), maxLimit);
+        return this;
+    }
+
+    @Override
+    public ListWithDefaultNullFW tryWrap(
+        DirectBuffer buffer,
+        int offset,
+        int maxLimit)
+    {
+        if (super.tryWrap(buffer, offset, maxLimit) == null)
+        {
+            return null;
+        }
+        int fieldLimit = offset + FIRST_FIELD_OFFSET;
+        final int length = length();
+        for (int field = FIELD_INDEX_VARIANT_OF_STRING1; field < length; field++)
+        {
+            switch (field)
+            {
+            case FIELD_INDEX_VARIANT_OF_STRING1:
+                if (variantOfString1RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                {
+                    return null;
+                }
+                fieldLimit = variantOfString1RO.limit();
+                break;
+            case FIELD_INDEX_VARIANT_OF_STRING2:
+                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+                {
+                    if (variantOfString2RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                    {
+                        return null;
+                    }
+                    fieldLimit = variantOfString2RO.limit();
+                }
+                else
+                {
+                    fieldLimit++;
+                }
+                break;
+            case FIELD_INDEX_VARIANT_OF_UINT:
+                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+                {
+                    if (variantOfUintRO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                    {
+                        return null;
+                    }
+                    fieldLimit = variantOfUintRO.limit();
+                }
+                else
+                {
+                    fieldLimit++;
+                }
+                break;
+            case FIELD_INDEX_VARIANT_OF_INT:
+                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+                {
+                    if (variantOfIntRO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                    {
+                        return null;
+                    }
+                    fieldLimit = variantOfIntRO.limit();
+                }
+                else
+                {
+                    fieldLimit++;
+                }
+                break;
+            }
+        }
+        if (limit() > maxLimit)
+        {
+            return null;
+        }
+        return this;
+    }
+
+    @Override
+    public int limit()
+    {
+        return offset() + buffer().getInt(offset() + PHYSICAL_LENGTH_OFFSET);
+    }
+
+    @Override
+    public String toString()
+    {
+        boolean variantOfString2IsSet = length() > FIELD_INDEX_VARIANT_OF_STRING2 &&
+            buffer().getByte(variantOfString1RO.limit()) != DEFAULT_NULL_VALUE;
+        boolean variantOfIntIsSet = length() > FIELD_INDEX_VARIANT_OF_INT &&
+            buffer().getByte(variantOfUintRO.limit()) != DEFAULT_NULL_VALUE;
+
+        StringBuilder format = new StringBuilder();
+        format.append("LIST_WITH_DEFAULT_NULL [variantOfString1={0}");
+        if (variantOfString2IsSet)
+        {
+            format.append(", variantOfString2={1}");
+        }
+        format.append(", variantOfUint={2}");
+        if (variantOfIntIsSet)
+        {
+            format.append(", variantOfInt={3}");
+        }
+
+        format.append("]");
+        return MessageFormat.format(format.toString(),
+            variantOfString1(),
+            variantOfString2IsSet ? variantOfString2() : null,
+            variantOfUint(),
+            variantOfIntIsSet ? variantOfInt() : null);
+    }
+
+    public static final class Builder extends Flyweight.Builder<ListWithDefaultNullFW>
+    {
+        private final VariantEnumKindWithString32FW.Builder variantOfString32RW = new VariantEnumKindWithString32FW.Builder();
+
+        private final VariantEnumKindOfUint32FW.Builder variantOfUint32RW = new VariantEnumKindOfUint32FW.Builder();
+
+        private final VariantEnumKindWithInt32FW.Builder variantOfInt32RW = new VariantEnumKindWithInt32FW.Builder();
+
+        private int lastFieldSet = -1;
+
+        public Builder()
+        {
+            super(new ListWithDefaultNullFW());
+        }
+
+        public Builder variantOfString1(
+            String value)
+        {
+            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING1 : "Field \"variantOfString1\" cannot be set out of order";
+            VariantEnumKindWithString32FW.Builder variantOfString1RW = this.variantOfString32RW.wrap(buffer(), limit(),
+                maxLimit());
+            variantOfString1RW.set(value);
+            lastFieldSet = FIELD_INDEX_VARIANT_OF_STRING1;
+            limit(variantOfString1RW.build().limit());
+            return this;
+        }
+
+        public Builder variantOfString2(
+            String value)
+        {
+            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2 : "Field \"variantOfString2\" cannot be set out of order";
+            assert lastFieldSet == FIELD_INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
+            VariantEnumKindWithString32FW.Builder variantOfString2RW = this.variantOfString32RW.wrap(buffer(), limit(),
+                maxLimit());
+            variantOfString2RW.set(value);
+            lastFieldSet = FIELD_INDEX_VARIANT_OF_STRING2;
+            limit(variantOfString2RW.build().limit());
+            return this;
+        }
+
+        private Builder variantOfString2()
+        {
+            assert lastFieldSet == FIELD_INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
+            int newLimit = limit() + SIZE_OF_BYTE;
+            checkLimit(limit(), newLimit);
+            buffer().putByte(limit(), DEFAULT_NULL_VALUE);
+            lastFieldSet = FIELD_INDEX_VARIANT_OF_STRING2;
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder variantOfUint(
+            long value)
+        {
+            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_UINT : "Field \"variantOfUint\" cannot be set out of order";
+            if (lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2)
+            {
+                variantOfString2();
+            }
+            VariantEnumKindOfUint32FW.Builder variantOfUintRW = this.variantOfUint32RW.wrap(buffer(), limit(), maxLimit());
+            variantOfUintRW.set(value);
+            lastFieldSet = FIELD_INDEX_VARIANT_OF_UINT;
+            limit(variantOfUintRW.build().limit());
+            return this;
+        }
+
+        private Builder variantOfUint()
+        {
+            if (lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2)
+            {
+                variantOfString2();
+            }
+            int newLimit = limit() + SIZE_OF_BYTE;
+            checkLimit(limit(), newLimit);
+            buffer().putByte(limit(), DEFAULT_NULL_VALUE);
+            lastFieldSet = FIELD_INDEX_VARIANT_OF_UINT;
+            limit(newLimit);
+            return this;
+        }
+
+        public Builder variantOfInt(
+            int value)
+        {
+            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_INT : "Field \"variantOfInt\" cannot be set out of order";
+            if (lastFieldSet < FIELD_INDEX_VARIANT_OF_UINT)
+            {
+                variantOfUint();
+            }
+            VariantEnumKindWithInt32FW.Builder variantOfIntRW = this.variantOfInt32RW.wrap(buffer(), limit(), maxLimit());
+            variantOfIntRW.set(value);
+            lastFieldSet = FIELD_INDEX_VARIANT_OF_INT;
+            limit(variantOfIntRW.build().limit());
+            return this;
+        }
+
+        @Override
+        public Builder wrap(
+            MutableDirectBuffer buffer,
+            int offset,
+            int maxLimit)
+        {
+            super.wrap(buffer, offset, maxLimit);
+            lastFieldSet = -1;
+            int newLimit = limit() + FIRST_FIELD_OFFSET;
+            checkLimit(newLimit, maxLimit());
+            limit(newLimit);
+            return this;
+        }
+
+        @Override
+        public ListWithDefaultNullFW build()
+        {
+            assert lastFieldSet >= FIELD_INDEX_VARIANT_OF_STRING1 : "Required field \"variantOfString1\" is not set";
+            buffer().putInt(offset() + PHYSICAL_LENGTH_OFFSET, limit() - offset());
+            buffer().putInt(offset() + LOGICAL_LENGTH_OFFSET, lastFieldSet + 1);
+            return super.build();
+        }
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -43,19 +43,23 @@ public class ListWithDefaultNullFW extends Flyweight
 
     private static final int INDEX_VARIANT_OF_STRING1 = 0;
 
+    private static final long MASK_VARIANT_OF_STRING1 = 1 << INDEX_VARIANT_OF_STRING1;
+
     private static final int INDEX_VARIANT_OF_STRING2 = 1;
 
-    private static final int MASK_VARIANT_OF_STRING2 = 1 << INDEX_VARIANT_OF_STRING2;
+    private static final long MASK_VARIANT_OF_STRING2 = 1 << INDEX_VARIANT_OF_STRING2;
 
     private static final int INDEX_VARIANT_OF_UINT = 2;
 
-    private static final int MASK_VARIANT_OF_UINT = 1 << INDEX_VARIANT_OF_UINT;
+    private static final long MASK_VARIANT_OF_UINT = 1 << INDEX_VARIANT_OF_UINT;
 
     private static final int INDEX_VARIANT_OF_INT = 3;
 
-    private static final int MASK_VARIANT_OF_INT = 1 << INDEX_VARIANT_OF_INT;
+    private static final long MASK_VARIANT_OF_INT = 1 << INDEX_VARIANT_OF_INT;
 
     private static final long DEFAULT_VARIANT_OF_UINT = 4000000000L;
+
+    private static final int NULL_VALUE_SIZE = BitUtil.SIZE_OF_BYTE;
 
     private VariantEnumKindWithString32FW variantOfString1RO = new VariantEnumKindWithString32FW();
 
@@ -74,23 +78,24 @@ public class ListWithDefaultNullFW extends Flyweight
 
     public String variantOfString1()
     {
+        assert (bitmask & MASK_VARIANT_OF_STRING1) != 0L : "Field \"variantOfString1\" is not set";
         return variantOfString1RO.get();
     }
 
     public String variantOfString2()
     {
-        assert (bitmask & MASK_VARIANT_OF_STRING2) != 0 : "Field \"variantOfString2\" is not set";
+        assert (bitmask & MASK_VARIANT_OF_STRING2) != 0L : "Field \"variantOfString2\" is not set";
         return variantOfString2RO.get();
     }
 
     public long variantOfUint()
     {
-        return (bitmask & MASK_VARIANT_OF_UINT) != 0 ? variantOfUintRO.get() : DEFAULT_VARIANT_OF_UINT;
+        return (bitmask & MASK_VARIANT_OF_UINT) != 0L ? variantOfUintRO.get() : DEFAULT_VARIANT_OF_UINT;
     }
 
     public int variantOfInt()
     {
-        assert (bitmask & MASK_VARIANT_OF_INT) != 0 : "Field \"variantOfInt\" is not set";
+        assert (bitmask & MASK_VARIANT_OF_INT) != 0L : "Field \"variantOfInt\" is not set";
         return variantOfIntRO.get();
     }
 
@@ -122,7 +127,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 else
                 {
-                    fieldLimit++;
+                    fieldLimit += NULL_VALUE_SIZE;
                 }
                 break;
             case INDEX_VARIANT_OF_UINT:
@@ -134,7 +139,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 else
                 {
-                    fieldLimit++;
+                    fieldLimit += NULL_VALUE_SIZE;
                 }
                 break;
             case INDEX_VARIANT_OF_INT:
@@ -146,7 +151,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 else
                 {
-                    fieldLimit++;
+                    fieldLimit += NULL_VALUE_SIZE;
                 }
                 break;
             }
@@ -192,7 +197,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 else
                 {
-                    fieldLimit++;
+                    fieldLimit += NULL_VALUE_SIZE;
                 }
                 break;
             case INDEX_VARIANT_OF_UINT:
@@ -207,7 +212,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 else
                 {
-                    fieldLimit++;
+                    fieldLimit += NULL_VALUE_SIZE;
                 }
                 break;
             case INDEX_VARIANT_OF_INT:
@@ -222,7 +227,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 else
                 {
-                    fieldLimit++;
+                    fieldLimit += NULL_VALUE_SIZE;
                 }
                 break;
             }
@@ -243,27 +248,29 @@ public class ListWithDefaultNullFW extends Flyweight
     @Override
     public String toString()
     {
-        boolean variantOfString2IsSet = (bitmask & MASK_VARIANT_OF_STRING2) != 0;
-        boolean variantOfIntIsSet = (bitmask & MASK_VARIANT_OF_INT) != 0;
+        Object variantOfString2 = null;
+        Object variantOfInt = null;
 
         StringBuilder format = new StringBuilder();
         format.append("LIST_WITH_DEFAULT_NULL [");
         format.append("variantOfString1={0}");
-        if (variantOfString2IsSet)
+        if ((bitmask & MASK_VARIANT_OF_STRING2) != 0L)
         {
             format.append(", variantOfString2={1}");
+            variantOfString2 = variantOfString2();
         }
         format.append(", variantOfUint={2}");
-        if (variantOfIntIsSet)
+        if ((bitmask & MASK_VARIANT_OF_INT) != 0L)
         {
             format.append(", variantOfInt={3}");
+            variantOfInt = variantOfInt();
         }
         format.append("]");
         return MessageFormat.format(format.toString(),
             variantOfString1(),
-            variantOfString2IsSet ? variantOfString2() : null,
+            variantOfString2,
             variantOfUint(),
-            variantOfIntIsSet ? variantOfInt() : null);
+            variantOfInt);
     }
 
     public static final class Builder extends Flyweight.Builder<ListWithDefaultNullFW>

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -106,11 +106,16 @@ public class ListWithDefaultNullFW extends Flyweight
         int maxLimit)
     {
         super.wrap(buffer, offset, maxLimit);
-        int fieldLimit = offset + FIRST_FIELD_OFFSET;
+        checkLimit(offset + PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE, maxLimit);
+        final int limit = limit();
+        checkLimit(limit, maxLimit);
+        checkLimit(offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE, limit);
         final int length = length();
         bitmask = 0;
+        int fieldLimit = offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE;
         for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
+            checkLimit(fieldLimit + SIZE_OF_BYTE, limit);
             switch (field)
             {
             case INDEX_VARIANT_OF_STRING1:
@@ -156,7 +161,6 @@ public class ListWithDefaultNullFW extends Flyweight
                 break;
             }
         }
-        checkLimit(limit(), maxLimit);
         return this;
     }
 
@@ -170,16 +174,25 @@ public class ListWithDefaultNullFW extends Flyweight
         {
             return null;
         }
-        int fieldLimit = offset + FIRST_FIELD_OFFSET;
-        if (fieldLimit > limit())
+        if (offset + PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE > maxLimit)
+        {
+            return null;
+        }
+        final int limit = limit();
+        if (limit > maxLimit)
+        {
+            return null;
+        }
+        if (offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE > limit)
         {
             return null;
         }
         final int length = length();
         bitmask = 0;
+        int fieldLimit = offset + LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE;
         for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
-            if (fieldLimit + SIZE_OF_BYTE > limit())
+            if (fieldLimit + SIZE_OF_BYTE > limit)
             {
                 return null;
             }
@@ -239,10 +252,6 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 break;
             }
-        }
-        if (limit() > maxLimit)
-        {
-            return null;
         }
         return this;
     }

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -59,6 +59,8 @@ public class ListWithDefaultNullFW extends Flyweight
 
     private VariantEnumKindWithInt32FW variantOfIntRO = new VariantEnumKindWithInt32FW();
 
+    private long bitmask;
+
     public int length()
     {
         return buffer().getInt(offset() + LOGICAL_LENGTH_OFFSET);
@@ -69,56 +71,21 @@ public class ListWithDefaultNullFW extends Flyweight
         return variantOfString1RO.get();
     }
 
-    private int fieldLimitVariantOfString1()
-    {
-        return variantOfString1RO.limit();
-    }
-
     public String variantOfString2()
     {
-        assert variantOfString2IsSet() : "Field \"variantOfString2\" is not set";
+        assert (bitmask & 1 << FIELD_INDEX_VARIANT_OF_STRING2) != 0 : "Field \"variantOfString2\" is not set";
         return variantOfString2RO.get();
-    }
-
-    private int fieldLimitVariantOfString2()
-    {
-        return variantOfString2IsSet() ? variantOfString2RO.limit() : fieldLimitVariantOfString1() + 1;
-    }
-
-    private boolean variantOfString2IsSet()
-    {
-        return length() > FIELD_INDEX_VARIANT_OF_STRING2 && buffer().getByte(fieldLimitVariantOfString1()) != DEFAULT_NULL_VALUE;
     }
 
     public long variantOfUint()
     {
-        return variantOfUintIsSet() ? variantOfUintRO.get() : FIELD_DEFAULT_VALUE_VARIANT_OF_UINT;
-    }
-
-    private int fieldLimitVariantOfUint()
-    {
-        return variantOfUintIsSet() ? variantOfUintRO.limit() : fieldLimitVariantOfString2() + 1;
-    }
-
-    private boolean variantOfUintIsSet()
-    {
-        return length() > FIELD_INDEX_VARIANT_OF_UINT && buffer().getByte(fieldLimitVariantOfString2()) != DEFAULT_NULL_VALUE;
+        return (bitmask & 1 << FIELD_INDEX_VARIANT_OF_UINT) != 0 ? variantOfUintRO.get() : FIELD_DEFAULT_VALUE_VARIANT_OF_UINT;
     }
 
     public int variantOfInt()
     {
-        assert variantOfIntIsSet() : "Field \"variantOfInt\" is not set";
+        assert (bitmask & 1 << FIELD_INDEX_VARIANT_OF_INT) != 0 : "Field \"variantOfInt\" is not set";
         return variantOfIntRO.get();
-    }
-
-    private int fieldLimitVariantOfInt()
-    {
-        return variantOfIntIsSet() ? variantOfIntRO.limit() : fieldLimitVariantOfUint() + 1;
-    }
-
-    private boolean variantOfIntIsSet()
-    {
-        return length() > FIELD_INDEX_VARIANT_OF_INT && buffer().getByte(fieldLimitVariantOfUint()) != DEFAULT_NULL_VALUE;
     }
 
     @Override
@@ -137,12 +104,14 @@ public class ListWithDefaultNullFW extends Flyweight
             case FIELD_INDEX_VARIANT_OF_STRING1:
                 variantOfString1RO.wrap(buffer, fieldLimit, maxLimit);
                 fieldLimit = variantOfString1RO.limit();
+                bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING1;
                 break;
             case FIELD_INDEX_VARIANT_OF_STRING2:
                 if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
                 {
                     variantOfString2RO.wrap(buffer, fieldLimit, maxLimit);
                     fieldLimit = variantOfString2RO.limit();
+                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING2;
                 }
                 else
                 {
@@ -154,6 +123,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 {
                     variantOfUintRO.wrap(buffer, fieldLimit, maxLimit);
                     fieldLimit = variantOfUintRO.limit();
+                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_UINT;
                 }
                 else
                 {
@@ -165,6 +135,7 @@ public class ListWithDefaultNullFW extends Flyweight
                 {
                     variantOfIntRO.wrap(buffer, fieldLimit, maxLimit);
                     fieldLimit = variantOfIntRO.limit();
+                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_INT;
                 }
                 else
                 {
@@ -199,6 +170,7 @@ public class ListWithDefaultNullFW extends Flyweight
                     return null;
                 }
                 fieldLimit = variantOfString1RO.limit();
+                bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING1;
                 break;
             case FIELD_INDEX_VARIANT_OF_STRING2:
                 if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
@@ -208,6 +180,7 @@ public class ListWithDefaultNullFW extends Flyweight
                         return null;
                     }
                     fieldLimit = variantOfString2RO.limit();
+                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING2;
                 }
                 else
                 {
@@ -222,6 +195,7 @@ public class ListWithDefaultNullFW extends Flyweight
                         return null;
                     }
                     fieldLimit = variantOfUintRO.limit();
+                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_UINT;
                 }
                 else
                 {
@@ -236,6 +210,7 @@ public class ListWithDefaultNullFW extends Flyweight
                         return null;
                     }
                     fieldLimit = variantOfIntRO.limit();
+                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_INT;
                 }
                 else
                 {
@@ -325,7 +300,7 @@ public class ListWithDefaultNullFW extends Flyweight
             return this;
         }
 
-        private Builder variantOfString2()
+        private Builder defaultVariantOfString2()
         {
             assert lastFieldSet == FIELD_INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
             int newLimit = limit() + SIZE_OF_BYTE;
@@ -342,7 +317,7 @@ public class ListWithDefaultNullFW extends Flyweight
             assert lastFieldSet < FIELD_INDEX_VARIANT_OF_UINT : "Field \"variantOfUint\" cannot be set out of order";
             if (lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2)
             {
-                variantOfString2();
+                defaultVariantOfString2();
             }
             VariantEnumKindOfUint32FW.Builder variantOfUintRW = this.variantOfUint32RW.wrap(buffer(), limit(), maxLimit());
             variantOfUintRW.set(value);
@@ -351,11 +326,11 @@ public class ListWithDefaultNullFW extends Flyweight
             return this;
         }
 
-        private Builder variantOfUint()
+        private Builder defaultVariantOfUint()
         {
             if (lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2)
             {
-                variantOfString2();
+                defaultVariantOfString2();
             }
             int newLimit = limit() + SIZE_OF_BYTE;
             checkLimit(limit(), newLimit);
@@ -371,7 +346,7 @@ public class ListWithDefaultNullFW extends Flyweight
             assert lastFieldSet < FIELD_INDEX_VARIANT_OF_INT : "Field \"variantOfInt\" cannot be set out of order";
             if (lastFieldSet < FIELD_INDEX_VARIANT_OF_UINT)
             {
-                variantOfUint();
+                defaultVariantOfUint();
             }
             VariantEnumKindWithInt32FW.Builder variantOfIntRW = this.variantOfInt32RW.wrap(buffer(), limit(), maxLimit());
             variantOfIntRW.set(value);

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -37,19 +37,25 @@ public class ListWithDefaultNullFW extends Flyweight
 
     private static final int LOGICAL_LENGTH_SIZE = BitUtil.SIZE_OF_INT;
 
-    private static final byte DEFAULT_NULL_VALUE = 0x40;
+    private static final byte NULL_VALUE = 0x40;
 
     private static final int FIRST_FIELD_OFFSET = LOGICAL_LENGTH_OFFSET + LOGICAL_LENGTH_SIZE;
 
-    private static final int FIELD_INDEX_VARIANT_OF_STRING1 = 0;
+    private static final int INDEX_VARIANT_OF_STRING1 = 0;
 
-    private static final int FIELD_INDEX_VARIANT_OF_STRING2 = 1;
+    private static final int INDEX_VARIANT_OF_STRING2 = 1;
 
-    private static final int FIELD_INDEX_VARIANT_OF_UINT = 2;
+    private static final int MASK_VARIANT_OF_STRING2 = 1 << INDEX_VARIANT_OF_STRING2;
 
-    private static final int FIELD_INDEX_VARIANT_OF_INT = 3;
+    private static final int INDEX_VARIANT_OF_UINT = 2;
 
-    private static final long FIELD_DEFAULT_VALUE_VARIANT_OF_UINT = 4000000000L;
+    private static final int MASK_VARIANT_OF_UINT = 1 << INDEX_VARIANT_OF_UINT;
+
+    private static final int INDEX_VARIANT_OF_INT = 3;
+
+    private static final int MASK_VARIANT_OF_INT = 1 << INDEX_VARIANT_OF_INT;
+
+    private static final long DEFAULT_VARIANT_OF_UINT = 4000000000L;
 
     private VariantEnumKindWithString32FW variantOfString1RO = new VariantEnumKindWithString32FW();
 
@@ -73,18 +79,18 @@ public class ListWithDefaultNullFW extends Flyweight
 
     public String variantOfString2()
     {
-        assert (bitmask & 1 << FIELD_INDEX_VARIANT_OF_STRING2) != 0 : "Field \"variantOfString2\" is not set";
+        assert (bitmask & MASK_VARIANT_OF_STRING2) != 0 : "Field \"variantOfString2\" is not set";
         return variantOfString2RO.get();
     }
 
     public long variantOfUint()
     {
-        return (bitmask & 1 << FIELD_INDEX_VARIANT_OF_UINT) != 0 ? variantOfUintRO.get() : FIELD_DEFAULT_VALUE_VARIANT_OF_UINT;
+        return (bitmask & MASK_VARIANT_OF_UINT) != 0 ? variantOfUintRO.get() : DEFAULT_VARIANT_OF_UINT;
     }
 
     public int variantOfInt()
     {
-        assert (bitmask & 1 << FIELD_INDEX_VARIANT_OF_INT) != 0 : "Field \"variantOfInt\" is not set";
+        assert (bitmask & MASK_VARIANT_OF_INT) != 0 : "Field \"variantOfInt\" is not set";
         return variantOfIntRO.get();
     }
 
@@ -96,46 +102,47 @@ public class ListWithDefaultNullFW extends Flyweight
     {
         super.wrap(buffer, offset, maxLimit);
         int fieldLimit = offset + FIRST_FIELD_OFFSET;
+        bitmask = 0;
         final int length = length();
-        for (int field = FIELD_INDEX_VARIANT_OF_STRING1; field < length; field++)
+        for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
             switch (field)
             {
-            case FIELD_INDEX_VARIANT_OF_STRING1:
+            case INDEX_VARIANT_OF_STRING1:
                 variantOfString1RO.wrap(buffer, fieldLimit, maxLimit);
                 fieldLimit = variantOfString1RO.limit();
-                bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING1;
+                bitmask |= 1 << INDEX_VARIANT_OF_STRING1;
                 break;
-            case FIELD_INDEX_VARIANT_OF_STRING2:
-                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+            case INDEX_VARIANT_OF_STRING2:
+                if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     variantOfString2RO.wrap(buffer, fieldLimit, maxLimit);
                     fieldLimit = variantOfString2RO.limit();
-                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING2;
+                    bitmask |= 1 << INDEX_VARIANT_OF_STRING2;
                 }
                 else
                 {
                     fieldLimit++;
                 }
                 break;
-            case FIELD_INDEX_VARIANT_OF_UINT:
-                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+            case INDEX_VARIANT_OF_UINT:
+                if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     variantOfUintRO.wrap(buffer, fieldLimit, maxLimit);
                     fieldLimit = variantOfUintRO.limit();
-                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_UINT;
+                    bitmask |= 1 << INDEX_VARIANT_OF_UINT;
                 }
                 else
                 {
                     fieldLimit++;
                 }
                 break;
-            case FIELD_INDEX_VARIANT_OF_INT:
-                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+            case INDEX_VARIANT_OF_INT:
+                if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     variantOfIntRO.wrap(buffer, fieldLimit, maxLimit);
                     fieldLimit = variantOfIntRO.limit();
-                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_INT;
+                    bitmask |= 1 << INDEX_VARIANT_OF_INT;
                 }
                 else
                 {
@@ -159,58 +166,59 @@ public class ListWithDefaultNullFW extends Flyweight
             return null;
         }
         int fieldLimit = offset + FIRST_FIELD_OFFSET;
+        bitmask = 0;
         final int length = length();
-        for (int field = FIELD_INDEX_VARIANT_OF_STRING1; field < length; field++)
+        for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
             switch (field)
             {
-            case FIELD_INDEX_VARIANT_OF_STRING1:
+            case INDEX_VARIANT_OF_STRING1:
                 if (variantOfString1RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                 {
                     return null;
                 }
                 fieldLimit = variantOfString1RO.limit();
-                bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING1;
+                bitmask |= 1 << INDEX_VARIANT_OF_STRING1;
                 break;
-            case FIELD_INDEX_VARIANT_OF_STRING2:
-                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+            case INDEX_VARIANT_OF_STRING2:
+                if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfString2RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
                     fieldLimit = variantOfString2RO.limit();
-                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_STRING2;
+                    bitmask |= 1 << INDEX_VARIANT_OF_STRING2;
                 }
                 else
                 {
                     fieldLimit++;
                 }
                 break;
-            case FIELD_INDEX_VARIANT_OF_UINT:
-                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+            case INDEX_VARIANT_OF_UINT:
+                if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfUintRO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
                     fieldLimit = variantOfUintRO.limit();
-                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_UINT;
+                    bitmask |= 1 << INDEX_VARIANT_OF_UINT;
                 }
                 else
                 {
                     fieldLimit++;
                 }
                 break;
-            case FIELD_INDEX_VARIANT_OF_INT:
-                if (buffer().getByte(fieldLimit) != DEFAULT_NULL_VALUE)
+            case INDEX_VARIANT_OF_INT:
+                if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfIntRO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
                     fieldLimit = variantOfIntRO.limit();
-                    bitmask |= 1 << FIELD_INDEX_VARIANT_OF_INT;
+                    bitmask |= 1 << INDEX_VARIANT_OF_INT;
                 }
                 else
                 {
@@ -235,13 +243,12 @@ public class ListWithDefaultNullFW extends Flyweight
     @Override
     public String toString()
     {
-        boolean variantOfString2IsSet = length() > FIELD_INDEX_VARIANT_OF_STRING2 &&
-            buffer().getByte(variantOfString1RO.limit()) != DEFAULT_NULL_VALUE;
-        boolean variantOfIntIsSet = length() > FIELD_INDEX_VARIANT_OF_INT &&
-            buffer().getByte(variantOfUintRO.limit()) != DEFAULT_NULL_VALUE;
+        boolean variantOfString2IsSet = (bitmask & MASK_VARIANT_OF_STRING2) != 0;
+        boolean variantOfIntIsSet = (bitmask & MASK_VARIANT_OF_INT) != 0;
 
         StringBuilder format = new StringBuilder();
-        format.append("LIST_WITH_DEFAULT_NULL [variantOfString1={0}");
+        format.append("LIST_WITH_DEFAULT_NULL [");
+        format.append("variantOfString1={0}");
         if (variantOfString2IsSet)
         {
             format.append(", variantOfString2={1}");
@@ -251,7 +258,6 @@ public class ListWithDefaultNullFW extends Flyweight
         {
             format.append(", variantOfInt={3}");
         }
-
         format.append("]");
         return MessageFormat.format(format.toString(),
             variantOfString1(),
@@ -278,11 +284,11 @@ public class ListWithDefaultNullFW extends Flyweight
         public Builder variantOfString1(
             String value)
         {
-            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING1 : "Field \"variantOfString1\" cannot be set out of order";
+            assert lastFieldSet < INDEX_VARIANT_OF_STRING1 : "Field \"variantOfString1\" cannot be set out of order";
             VariantEnumKindWithString32FW.Builder variantOfString1RW = this.variantOfString32RW.wrap(buffer(), limit(),
                 maxLimit());
             variantOfString1RW.set(value);
-            lastFieldSet = FIELD_INDEX_VARIANT_OF_STRING1;
+            lastFieldSet = INDEX_VARIANT_OF_STRING1;
             limit(variantOfString1RW.build().limit());
             return this;
         }
@@ -290,23 +296,23 @@ public class ListWithDefaultNullFW extends Flyweight
         public Builder variantOfString2(
             String value)
         {
-            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2 : "Field \"variantOfString2\" cannot be set out of order";
-            assert lastFieldSet == FIELD_INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
+            assert lastFieldSet < INDEX_VARIANT_OF_STRING2 : "Field \"variantOfString2\" cannot be set out of order";
+            assert lastFieldSet == INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
             VariantEnumKindWithString32FW.Builder variantOfString2RW = this.variantOfString32RW.wrap(buffer(), limit(),
                 maxLimit());
             variantOfString2RW.set(value);
-            lastFieldSet = FIELD_INDEX_VARIANT_OF_STRING2;
+            lastFieldSet = INDEX_VARIANT_OF_STRING2;
             limit(variantOfString2RW.build().limit());
             return this;
         }
 
         private Builder defaultVariantOfString2()
         {
-            assert lastFieldSet == FIELD_INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
+            assert lastFieldSet == INDEX_VARIANT_OF_STRING1 : "Prior required field \"variantOfString1\" is not set";
             int newLimit = limit() + SIZE_OF_BYTE;
             checkLimit(limit(), newLimit);
-            buffer().putByte(limit(), DEFAULT_NULL_VALUE);
-            lastFieldSet = FIELD_INDEX_VARIANT_OF_STRING2;
+            buffer().putByte(limit(), NULL_VALUE);
+            lastFieldSet = INDEX_VARIANT_OF_STRING2;
             limit(newLimit);
             return this;
         }
@@ -314,28 +320,28 @@ public class ListWithDefaultNullFW extends Flyweight
         public Builder variantOfUint(
             long value)
         {
-            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_UINT : "Field \"variantOfUint\" cannot be set out of order";
-            if (lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2)
+            assert lastFieldSet < INDEX_VARIANT_OF_UINT : "Field \"variantOfUint\" cannot be set out of order";
+            if (lastFieldSet < INDEX_VARIANT_OF_STRING2)
             {
                 defaultVariantOfString2();
             }
             VariantEnumKindOfUint32FW.Builder variantOfUintRW = this.variantOfUint32RW.wrap(buffer(), limit(), maxLimit());
             variantOfUintRW.set(value);
-            lastFieldSet = FIELD_INDEX_VARIANT_OF_UINT;
+            lastFieldSet = INDEX_VARIANT_OF_UINT;
             limit(variantOfUintRW.build().limit());
             return this;
         }
 
         private Builder defaultVariantOfUint()
         {
-            if (lastFieldSet < FIELD_INDEX_VARIANT_OF_STRING2)
+            if (lastFieldSet < INDEX_VARIANT_OF_STRING2)
             {
                 defaultVariantOfString2();
             }
             int newLimit = limit() + SIZE_OF_BYTE;
             checkLimit(limit(), newLimit);
-            buffer().putByte(limit(), DEFAULT_NULL_VALUE);
-            lastFieldSet = FIELD_INDEX_VARIANT_OF_UINT;
+            buffer().putByte(limit(), NULL_VALUE);
+            lastFieldSet = INDEX_VARIANT_OF_UINT;
             limit(newLimit);
             return this;
         }
@@ -343,14 +349,14 @@ public class ListWithDefaultNullFW extends Flyweight
         public Builder variantOfInt(
             int value)
         {
-            assert lastFieldSet < FIELD_INDEX_VARIANT_OF_INT : "Field \"variantOfInt\" cannot be set out of order";
-            if (lastFieldSet < FIELD_INDEX_VARIANT_OF_UINT)
+            assert lastFieldSet < INDEX_VARIANT_OF_INT : "Field \"variantOfInt\" cannot be set out of order";
+            if (lastFieldSet < INDEX_VARIANT_OF_UINT)
             {
                 defaultVariantOfUint();
             }
             VariantEnumKindWithInt32FW.Builder variantOfIntRW = this.variantOfInt32RW.wrap(buffer(), limit(), maxLimit());
             variantOfIntRW.set(value);
-            lastFieldSet = FIELD_INDEX_VARIANT_OF_INT;
+            lastFieldSet = INDEX_VARIANT_OF_INT;
             limit(variantOfIntRW.build().limit());
             return this;
         }
@@ -372,7 +378,7 @@ public class ListWithDefaultNullFW extends Flyweight
         @Override
         public ListWithDefaultNullFW build()
         {
-            assert lastFieldSet >= FIELD_INDEX_VARIANT_OF_STRING1 : "Required field \"variantOfString1\" is not set";
+            assert lastFieldSet >= INDEX_VARIANT_OF_STRING1 : "Required field \"variantOfString1\" is not set";
             buffer().putInt(offset() + PHYSICAL_LENGTH_OFFSET, limit() - offset());
             buffer().putInt(offset() + LOGICAL_LENGTH_OFFSET, lastFieldSet + 1);
             return super.build();

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -172,6 +172,10 @@ public class ListWithDefaultNullFW extends Flyweight
         }
         int fieldLimit = offset + FIRST_FIELD_OFFSET;
         bitmask = 0;
+        if (fieldLimit > limit())
+        {
+            return null;
+        }
         final int length = length();
         for (int field = INDEX_VARIANT_OF_STRING1; field < length; field++)
         {
@@ -186,6 +190,10 @@ public class ListWithDefaultNullFW extends Flyweight
                 bitmask |= 1 << INDEX_VARIANT_OF_STRING1;
                 break;
             case INDEX_VARIANT_OF_STRING2:
+                if (fieldLimit + SIZE_OF_BYTE > limit())
+                {
+                    return null;
+                }
                 if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfString2RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
@@ -201,6 +209,10 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 break;
             case INDEX_VARIANT_OF_UINT:
+                if (fieldLimit + SIZE_OF_BYTE > limit())
+                {
+                    return null;
+                }
                 if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfUintRO.tryWrap(buffer, fieldLimit, maxLimit) == null)
@@ -216,6 +228,10 @@ public class ListWithDefaultNullFW extends Flyweight
                 }
                 break;
             case INDEX_VARIANT_OF_INT:
+                if (fieldLimit + SIZE_OF_BYTE > limit())
+                {
+                    return null;
+                }
                 if (buffer().getByte(fieldLimit) != NULL_VALUE)
                 {
                     if (variantOfIntRO.tryWrap(buffer, fieldLimit, maxLimit) == null)

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -29,11 +29,11 @@ import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindWithStrin
 
 public class ListWithDefaultNullFW extends Flyweight
 {
-    public static final int PHYSICAL_LENGTH_OFFSET = 0;
+    private static final int PHYSICAL_LENGTH_OFFSET = 0;
 
     private static final int PHYSICAL_LENGTH_SIZE = BitUtil.SIZE_OF_INT;
 
-    public static final int LOGICAL_LENGTH_OFFSET = PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE;
+    private static final int LOGICAL_LENGTH_OFFSET = PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE;
 
     private static final int LOGICAL_LENGTH_SIZE = BitUtil.SIZE_OF_INT;
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFW.java
@@ -249,7 +249,10 @@ public class ListWithDefaultNullFW extends Flyweight
                 break;
             }
         }
-        checkLimit(fieldLimit, limit);
+        if (fieldLimit > limit)
+        {
+            return null;
+        }
         return this;
     }
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithDefaultNullFWTest.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright 2016-2019 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt8;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint32;
+
+public class ListWithDefaultNullFWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+    private final ListWithDefaultNullFW.Builder listWithDefaultNullRW = new ListWithDefaultNullFW.Builder();
+    private final ListWithDefaultNullFW listWithDefaultNullRO = new ListWithDefaultNullFW();
+    private final int physicalLengthSize = Integer.BYTES;
+    private final int logicalLengthSize = Integer.BYTES;
+
+    private void setAllFields(
+        MutableDirectBuffer buffer)
+    {
+        int physicalLength = 47;
+        int logicalLength = 4;
+        int offsetPhysicalLength = 10;
+        buffer.putInt(offsetPhysicalLength, physicalLength);
+        int offsetLogicalLength = offsetPhysicalLength + physicalLengthSize;
+        buffer.putInt(offsetLogicalLength, logicalLength);
+
+        int offsetVariantOfString1Kind = offsetLogicalLength + logicalLengthSize;
+        buffer.putByte(offsetVariantOfString1Kind, EnumWithInt8.ONE.value());
+        int offsetVariantOfString1Length = offsetVariantOfString1Kind + Byte.BYTES;
+        buffer.putByte(offsetVariantOfString1Length, (byte) "string1".length());
+        int offsetVariantOfString1 = offsetVariantOfString1Length + Byte.BYTES;
+        buffer.putBytes(offsetVariantOfString1, "string1".getBytes());
+
+        int offsetVariantOfString2Kind = offsetVariantOfString1 + "string1".length();
+        buffer.putByte(offsetVariantOfString2Kind, EnumWithInt8.ONE.value());
+        int offsetVariantOfString2Length = offsetVariantOfString2Kind + Byte.BYTES;
+        buffer.putByte(offsetVariantOfString2Length, (byte) "string2".length());
+        int offsetVariantOfString2 = offsetVariantOfString2Length + Byte.BYTES;
+        buffer.putBytes(offsetVariantOfString2, "string2".getBytes());
+
+        int offsetVariantOfUintKind = offsetVariantOfString2 + "string2".length();
+        buffer.putLong(offsetVariantOfUintKind, EnumWithUint32.NI.value());
+        int offsetVariantOfUint = offsetVariantOfUintKind + Long.BYTES;
+        buffer.putLong(offsetVariantOfUint, 4000000000L);
+
+        int offsetVariantOfIntKind = offsetVariantOfUint + Long.BYTES;
+        buffer.putByte(offsetVariantOfIntKind, EnumWithInt8.THREE.value());
+        int offsetVariantOfInt = offsetVariantOfIntKind + Byte.BYTES;
+        buffer.putInt(offsetVariantOfInt, -2000000000);
+    }
+
+    @Test
+    public void shouldNotWrapWhenLengthInsufficientForMinimumRequiredLength()
+    {
+        int physicalLength = 47;
+        setAllFields(buffer);
+        for (int maxLimit = 10; maxLimit <= physicalLength; maxLimit++)
+        {
+            try
+            {
+                listWithDefaultNullRO.wrap(buffer,  10, maxLimit);
+                fail("Exception not thrown");
+            }
+            catch (Exception e)
+            {
+                if (!(e instanceof IndexOutOfBoundsException))
+                {
+                    fail("Unexpected exception " + e);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldNotTryWrapWhenLengthInsufficientForMinimumRequiredLength()
+    {
+        int physicalLength = 47;
+        int offsetPhysicalLength = 10;
+        setAllFields(buffer);
+        for (int maxLimit = 10; maxLimit <= physicalLength; maxLimit++)
+        {
+            assertNull(listWithDefaultNullRO.tryWrap(buffer,  offsetPhysicalLength, maxLimit));
+        }
+    }
+
+    @Test
+    public void shouldWrapWhenLengthSufficientForMinimumRequiredLength()
+    {
+        int physicalLength = 47;
+        int logicalLength = 4;
+        int offsetPhysicalLength = 10;
+        setAllFields(buffer);
+
+        assertSame(listWithDefaultNullRO, listWithDefaultNullRO.wrap(buffer, offsetPhysicalLength,
+            offsetPhysicalLength + physicalLength));
+        assertEquals(physicalLength, listWithDefaultNullRO.limit() - offsetPhysicalLength);
+        assertEquals(logicalLength, listWithDefaultNullRO.length());
+        assertEquals("string1", listWithDefaultNullRO.variantOfString1());
+        assertEquals("string2", listWithDefaultNullRO.variantOfString2());
+        assertEquals(4000000000L, listWithDefaultNullRO.variantOfUint());
+        assertEquals(-2000000000, listWithDefaultNullRO.variantOfInt());
+    }
+
+    @Test
+    public void shouldTryWrapWhenLengthSufficientForMinimumRequiredLength()
+    {
+        int physicalLength = 47;
+        int logicalLength = 4;
+        int offsetPhysicalLength = 10;
+        setAllFields(buffer);
+
+        assertSame(listWithDefaultNullRO, listWithDefaultNullRO.tryWrap(buffer, offsetPhysicalLength,
+            offsetPhysicalLength + physicalLength));
+        assertEquals(physicalLength, listWithDefaultNullRO.limit() - offsetPhysicalLength);
+        assertEquals(logicalLength, listWithDefaultNullRO.length());
+        assertEquals("string1", listWithDefaultNullRO.variantOfString1());
+        assertEquals("string2", listWithDefaultNullRO.variantOfString2());
+        assertEquals(4000000000L, listWithDefaultNullRO.variantOfUint());
+        assertEquals(-2000000000, listWithDefaultNullRO.variantOfInt());
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void shouldFailToSetString1WithInsufficientSpace() throws Exception
+    {
+        listWithDefaultNullRW.wrap(buffer, 10, 17)
+            .variantOfString1("string1");
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFailWhenFieldIsSetOutOfOrder() throws Exception
+    {
+        listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString1("string1")
+            .variantOfUint(4000000000L)
+            .variantOfString2("string2")
+            .build();
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFailWhenSameFieldIsSetMoreThanOnce() throws Exception
+    {
+        listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString1("string1")
+            .variantOfString1("string2")
+            .build();
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldFailWhenRequiredFieldIsNotSet() throws Exception
+    {
+        listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString2("string2")
+            .build();
+    }
+
+    @Test(expected = AssertionError.class)
+    public void shouldAssertErrorWhenValueNotPresent() throws Exception
+    {
+        int limit = listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString1("string1")
+            .build()
+            .limit();
+        listWithDefaultNullRO.wrap(buffer,  0,  limit);
+        assertEquals("string2", listWithDefaultNullRO.variantOfString2());
+    }
+
+    @Test
+    public void shouldSetOnlyRequiredFields() throws Exception
+    {
+        int limit = listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString1("string1")
+            .build()
+            .limit();
+        listWithDefaultNullRO.wrap(buffer,  0,  limit);
+        assertEquals("string1", listWithDefaultNullRO.variantOfString1());
+        assertEquals(4000000000L, listWithDefaultNullRO.variantOfUint());
+    }
+
+    @Test
+    public void shouldSetSomeFields() throws Exception
+    {
+        int limit = listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString1("string1")
+            .variantOfUint(4000000000L)
+            .build()
+            .limit();
+        listWithDefaultNullRO.wrap(buffer,  0,  limit);
+        assertEquals("string1", listWithDefaultNullRO.variantOfString1());
+        assertEquals(4000000000L, listWithDefaultNullRO.variantOfUint());
+    }
+
+    @Test
+    public void shouldSetAllFields() throws Exception
+    {
+        int limit = listWithDefaultNullRW.wrap(buffer, 0, buffer.capacity())
+            .variantOfString1("string1")
+            .variantOfString2("string2")
+            .variantOfUint(4000000000L)
+            .variantOfInt(-2000000000)
+            .build()
+            .limit();
+        listWithDefaultNullRO.wrap(buffer,  0,  limit);
+        assertEquals("string1", listWithDefaultNullRO.variantOfString1());
+        assertEquals("string2", listWithDefaultNullRO.variantOfString2());
+        assertEquals(4000000000L, listWithDefaultNullRO.variantOfUint());
+        assertEquals(-2000000000, listWithDefaultNullRO.variantOfInt());
+    }
+}

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFW.java
@@ -190,7 +190,6 @@ public final class ListWithVariantFW extends Flyweight
         checkLimit(offset + PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE, maxLimit);
         final int limit = limit();
         checkLimit(limit, maxLimit);
-        checkLimit(offset + BIT_MASK_OFFSET + BIT_MASK_SIZE, limit);
         final long bitmask = bitmask();
         int fieldLimit = offset + BIT_MASK_OFFSET + BIT_MASK_SIZE;
         for (int field = INDEX_INT_FIELD1; field < INDEX_VARIANT_OF_STRING32 + 1; field++)
@@ -270,6 +269,7 @@ public final class ListWithVariantFW extends Flyweight
                 break;
             }
         }
+        checkLimit(fieldLimit, limit);
         return this;
     }
 
@@ -289,10 +289,6 @@ public final class ListWithVariantFW extends Flyweight
         }
         final int limit = limit();
         if (limit > maxLimit)
-        {
-            return null;
-        }
-        if (offset + BIT_MASK_OFFSET + BIT_MASK_SIZE > limit)
         {
             return null;
         }
@@ -399,6 +395,7 @@ public final class ListWithVariantFW extends Flyweight
                 break;
             }
         }
+        checkLimit(fieldLimit, limit);
         return this;
     }
 
@@ -462,7 +459,7 @@ public final class ListWithVariantFW extends Flyweight
         }
         format.append("]");
         return MessageFormat.format(format.toString(),
-            String.format("0x%16X", bitmask),
+            String.format("0x%16x", bitmask),
             intField1,
             variantOfInt64,
             variantOfInt8,

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFW.java
@@ -23,7 +23,11 @@ import org.agrona.MutableDirectBuffer;
 import org.reaktivity.reaktor.internal.test.types.Flyweight;
 import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfInt16FW;
 import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfInt8FW;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint16FW;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint32FW;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindOfUint8FW;
 import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindWithInt32FW;
+import org.reaktivity.reaktor.internal.test.types.inner.VariantEnumKindWithString32FW;
 import org.reaktivity.reaktor.internal.test.types.inner.VariantUint8KindWithInt64TypeFW;
 
 public final class ListWithVariantFW extends Flyweight
@@ -46,27 +50,67 @@ public final class ListWithVariantFW extends Flyweight
 
     private static final int FIELD_SIZE_INTFIELD2 = BitUtil.SIZE_OF_SHORT;
 
-    private static final int FIELD_INDEX_INTFIELD1 = 0;
+    private static final int INDEX_INT_FIELD1 = 0;
 
-    private static final int FIELD_INDEX_VARIANTOFINT64OFUINT8KIND = 1;
+    private static final long MASK_INT_FIELD1 = 1 << INDEX_INT_FIELD1;
 
-    private static final int FIELD_INDEX_VARIANTOFINT8ENUMKIND = 2;
+    private static final int INDEX_VARIANT_OF_INT64 = 1;
 
-    private static final int FIELD_INDEX_INTFIELD2 = 3;
+    private static final long MASK_VARIANT_OF_INT64 = 1 << INDEX_VARIANT_OF_INT64;
 
-    private static final int FIELD_INDEX_VARIANTOFINT16ENUMKIND = 4;
+    private static final int INDEX_VARIANT_OF_INT8 = 2;
 
-    private static final int FIELD_INDEX_VARIANTOFINT32ENUMKIND = 5;
+    private static final long MASK_VARIANT_OF_INT8 = 1 << INDEX_VARIANT_OF_INT8;
 
-    private final VariantUint8KindWithInt64TypeFW variantOfInt64Uint8KindRO = new VariantUint8KindWithInt64TypeFW();
+    private static final int INDEX_INT_FIELD2 = 3;
 
-    private final VariantEnumKindOfInt8FW variantOfInt8EnumKindRO = new VariantEnumKindOfInt8FW();
+    private static final long MASK_INT_FIELD2 = 1 << INDEX_INT_FIELD2;
 
-    private final VariantEnumKindOfInt16FW variantOfInt16EnumKindRO = new VariantEnumKindOfInt16FW();
+    private static final int INDEX_VARIANT_OF_INT16 = 4;
 
-    private final VariantEnumKindWithInt32FW variantOfInt32EnumKindRO = new VariantEnumKindWithInt32FW();
+    private static final long MASK_VARIANT_OF_INT16 = 1 << INDEX_VARIANT_OF_INT16;
 
-    private final int[] optionalOffsets = new int[FIELD_INDEX_VARIANTOFINT32ENUMKIND + 1];
+    private static final int INDEX_VARIANT_OF_INT32 = 5;
+
+    private static final long MASK_VARIANT_OF_INT32 = 1 << INDEX_VARIANT_OF_INT32;
+
+    private static final int INDEX_VARIANT_OF_UINT8 = 6;
+
+    private static final long MASK_VARIANT_OF_UINT8 = 1 << INDEX_VARIANT_OF_UINT8;
+
+    private static final int INDEX_VARIANT_OF_UINT16 = 7;
+
+    private static final long MASK_VARIANT_OF_UINT16 = 1 << INDEX_VARIANT_OF_UINT16;
+
+    private static final int DEFAULT_VALUE_VARIANT_OF_UINT16 = 60000;
+
+    private static final int INDEX_VARIANT_OF_UINT32 = 8;
+
+    private static final long MASK_VARIANT_OF_UINT32 = 1 << INDEX_VARIANT_OF_UINT32;
+
+    private static final long DEFAULT_VALUE_VARIANT_OF_UINT32 = 0;
+
+    private static final int INDEX_VARIANT_OF_STRING32 = 9;
+
+    private static final long MASK_VARIANT_OF_STRING32 = 1 << INDEX_VARIANT_OF_STRING32;
+
+    private VariantUint8KindWithInt64TypeFW variantOfInt64RO = new VariantUint8KindWithInt64TypeFW();
+
+    private VariantEnumKindOfInt8FW variantOfInt8RO = new VariantEnumKindOfInt8FW();
+
+    private VariantEnumKindOfInt16FW variantOfInt16RO = new VariantEnumKindOfInt16FW();
+
+    private VariantEnumKindWithInt32FW variantOfInt32RO = new VariantEnumKindWithInt32FW();
+
+    private VariantEnumKindOfUint8FW variantOfUint8RO = new VariantEnumKindOfUint8FW();
+
+    private VariantEnumKindOfUint16FW variantOfUint16RO = new VariantEnumKindOfUint16FW();
+
+    private VariantEnumKindOfUint32FW variantOfUint32RO = new VariantEnumKindOfUint32FW();
+
+    private VariantEnumKindWithString32FW variantOfString32RO = new VariantEnumKindWithString32FW();
+
+    private final int[] optionalOffsets = new int[INDEX_VARIANT_OF_STRING32 + 1];
 
     public int length()
     {
@@ -80,40 +124,61 @@ public final class ListWithVariantFW extends Flyweight
 
     public int intField1()
     {
-        assert (bitmask() & (1 << FIELD_INDEX_INTFIELD1)) != 0 : "Field \"intField1\" is not set";
-        return buffer().getByte(optionalOffsets[FIELD_INDEX_INTFIELD1]);
+        assert (bitmask() & MASK_INT_FIELD1) != 0L : "Field \"intField1\" is not set";
+        return buffer().getByte(optionalOffsets[INDEX_INT_FIELD1]);
     }
 
-    public long variantOfInt64Uint8Kind()
+    public long variantOfInt64()
     {
-        assert (bitmask() & (1 << FIELD_INDEX_VARIANTOFINT64OFUINT8KIND)) != 0 : "Field \"variantOfInt64Uint8Kind\" is not set";
-        return variantOfInt64Uint8KindRO.get();
+        assert (bitmask() & MASK_VARIANT_OF_INT64) != 0L : "Field \"variantOfInt64Uint8Kind\" is not set";
+        return variantOfInt64RO.get();
     }
 
-    public int variantOfInt8EnumKind()
+    public int variantOfInt8()
     {
-        assert (bitmask() & (1 << FIELD_INDEX_VARIANTOFINT8ENUMKIND)) != 0 : "Field \"variantOfInt8EnumKind\" is not set";
-        return variantOfInt8EnumKindRO.get();
+        assert (bitmask() & MASK_VARIANT_OF_INT8) != 0L : "Field \"variantOfInt8EnumKind\" is not set";
+        return variantOfInt8RO.get();
     }
 
     public int intField2()
     {
-        assert (bitmask() & (1 << FIELD_INDEX_INTFIELD2)) != 0 : "Field \"intField2\" is not set";
-        return buffer().getShort(optionalOffsets[FIELD_INDEX_INTFIELD2]);
+        assert (bitmask() & MASK_INT_FIELD2) != 0L : "Field \"intField2\" is not set";
+        return buffer().getShort(optionalOffsets[INDEX_INT_FIELD2]);
     }
 
-    public int variantOfInt16EnumKind()
+    public int variantOfInt16()
     {
-        assert (bitmask() & (1 << FIELD_INDEX_VARIANTOFINT16ENUMKIND)) != 0 : "Field \"variantOfInt16EnumKind\" is not set";
-        return variantOfInt16EnumKindRO.get();
+        assert (bitmask() & MASK_VARIANT_OF_INT16) != 0L : "Field \"variantOfInt16EnumKind\" is not set";
+        return variantOfInt16RO.get();
     }
 
-    public int variantOfInt32EnumKind()
+    public int variantOfInt32()
     {
-        assert (bitmask() & (1 << FIELD_INDEX_VARIANTOFINT32ENUMKIND)) != 0 : "Field \"variantOfInt32EnumKind\" is not set";
-        return variantOfInt32EnumKindRO.get();
+        assert (bitmask() & MASK_VARIANT_OF_INT32) != 0L : "Field \"variantOfInt32EnumKind\" is not set";
+        return variantOfInt32RO.get();
     }
 
+    public int variantOfUint8()
+    {
+        assert (bitmask() & MASK_VARIANT_OF_UINT8) != 0L : "Field \"variantOfUint8\" is not set";
+        return variantOfUint8RO.get();
+    }
+
+    public int variantOfUint16()
+    {
+        return (bitmask() & MASK_VARIANT_OF_UINT16) == 0 ? DEFAULT_VALUE_VARIANT_OF_UINT16 : variantOfUint16RO.get();
+    }
+
+    public long variantOfUint32()
+    {
+        return (bitmask() & MASK_VARIANT_OF_UINT32) == 0 ? DEFAULT_VALUE_VARIANT_OF_UINT32 : variantOfUint32RO.get();
+    }
+
+    public String variantOfString32()
+    {
+        assert (bitmask() & INDEX_VARIANT_OF_STRING32) != 0 : "Field \"variantOfString32\" is not set";
+        return variantOfString32RO.get();
+    }
 
     @Override
     public ListWithVariantFW wrap(
@@ -122,57 +187,89 @@ public final class ListWithVariantFW extends Flyweight
         int maxLimit)
     {
         super.wrap(buffer, offset, maxLimit);
+        checkLimit(offset + PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE, maxLimit);
+        final int limit = limit();
+        checkLimit(limit, maxLimit);
+        checkLimit(offset + BIT_MASK_OFFSET + BIT_MASK_SIZE, limit);
         final long bitmask = bitmask();
-        int fieldLimit = offset + FIRST_FIELD_OFFSET;
-        for (int field = FIELD_INDEX_INTFIELD1; field < FIELD_INDEX_VARIANTOFINT32ENUMKIND + 1; field++)
+        int fieldLimit = offset + BIT_MASK_OFFSET + BIT_MASK_SIZE;
+        for (int field = INDEX_INT_FIELD1; field < INDEX_VARIANT_OF_STRING32 + 1; field++)
         {
             switch (field)
             {
-            case FIELD_INDEX_INTFIELD1:
-                if ((bitmask & (1 << FIELD_INDEX_INTFIELD1)) != 0)
+            case INDEX_INT_FIELD1:
+                if ((bitmask & MASK_INT_FIELD1) != 0)
                 {
-                    optionalOffsets[FIELD_INDEX_INTFIELD1] = fieldLimit;
+                    optionalOffsets[INDEX_INT_FIELD1] = fieldLimit;
                     fieldLimit += FIELD_SIZE_INTFIELD1;
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT64OFUINT8KIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT64OFUINT8KIND)) != 0)
+            case INDEX_VARIANT_OF_INT64:
+                if ((bitmask & MASK_VARIANT_OF_INT64) != 0)
                 {
-                    variantOfInt64Uint8KindRO.wrap(buffer, fieldLimit, maxLimit);
-                    fieldLimit = variantOfInt64Uint8KindRO.limit();
+                    variantOfInt64RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfInt64RO.limit();
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT8ENUMKIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT8ENUMKIND)) != 0)
+            case INDEX_VARIANT_OF_INT8:
+                if ((bitmask & MASK_VARIANT_OF_INT8) != 0)
                 {
-                    variantOfInt8EnumKindRO.wrap(buffer, fieldLimit, maxLimit);
-                    fieldLimit = variantOfInt8EnumKindRO.limit();
+                    variantOfInt8RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfInt8RO.limit();
                 }
                 break;
-            case FIELD_INDEX_INTFIELD2:
-                if ((bitmask & (1 << FIELD_INDEX_INTFIELD2)) != 0)
+            case INDEX_INT_FIELD2:
+                if ((bitmask & MASK_INT_FIELD2) != 0)
                 {
-                    optionalOffsets[FIELD_INDEX_INTFIELD2] = fieldLimit;
+                    optionalOffsets[INDEX_INT_FIELD2] = fieldLimit;
                     fieldLimit += FIELD_SIZE_INTFIELD2;
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT16ENUMKIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT16ENUMKIND)) != 0)
+            case INDEX_VARIANT_OF_INT16:
+                if ((bitmask & MASK_VARIANT_OF_INT16) != 0)
                 {
-                    variantOfInt16EnumKindRO.wrap(buffer, fieldLimit, maxLimit);
-                    fieldLimit = variantOfInt16EnumKindRO.limit();
+                    variantOfInt16RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfInt16RO.limit();
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT32ENUMKIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT32ENUMKIND)) != 0)
+            case INDEX_VARIANT_OF_INT32:
+                if ((bitmask & MASK_VARIANT_OF_INT32) != 0)
                 {
-                    variantOfInt32EnumKindRO.wrap(buffer, fieldLimit, maxLimit);
-                    fieldLimit = variantOfInt32EnumKindRO.limit();
+                    variantOfInt32RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfInt32RO.limit();
+                }
+                break;
+            case INDEX_VARIANT_OF_UINT8:
+                if ((bitmask & MASK_VARIANT_OF_UINT8) == 0)
+                {
+                    throw new IllegalArgumentException("Field \"variantOfUint8\" is required but not set");
+                }
+                variantOfUint8RO.wrap(buffer, fieldLimit, maxLimit);
+                fieldLimit = variantOfUint8RO.limit();
+                break;
+            case INDEX_VARIANT_OF_UINT16:
+                if ((bitmask & MASK_VARIANT_OF_UINT16) != 0)
+                {
+                    variantOfUint16RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfUint16RO.limit();
+                }
+                break;
+            case INDEX_VARIANT_OF_UINT32:
+                if ((bitmask & MASK_VARIANT_OF_UINT32) != 0)
+                {
+                    variantOfUint32RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfUint32RO.limit();
+                }
+                break;
+            case INDEX_VARIANT_OF_STRING32:
+                if ((bitmask & MASK_VARIANT_OF_STRING32) != 0)
+                {
+                    variantOfString32RO.wrap(buffer, fieldLimit, maxLimit);
+                    fieldLimit = variantOfString32RO.limit();
                 }
                 break;
             }
         }
-        checkLimit(limit(), maxLimit);
         return this;
     }
 
@@ -186,79 +283,121 @@ public final class ListWithVariantFW extends Flyweight
         {
             return null;
         }
+        if (offset + PHYSICAL_LENGTH_OFFSET + PHYSICAL_LENGTH_SIZE > maxLimit)
+        {
+            return null;
+        }
+        final int limit = limit();
+        if (limit > maxLimit)
+        {
+            return null;
+        }
+        if (offset + BIT_MASK_OFFSET + BIT_MASK_SIZE > limit)
+        {
+            return null;
+        }
         final long bitmask = bitmask();
-        int fieldLimit = offset + FIRST_FIELD_OFFSET;
-        for (int field = FIELD_INDEX_INTFIELD1; field < FIELD_INDEX_VARIANTOFINT32ENUMKIND + 1; field++)
+        int fieldLimit = offset + BIT_MASK_OFFSET + BIT_MASK_SIZE;
+        for (int field = INDEX_INT_FIELD1; field < INDEX_VARIANT_OF_STRING32 + 1; field++)
         {
             switch (field)
             {
-            case FIELD_INDEX_INTFIELD1:
-                if ((bitmask & (1 << FIELD_INDEX_INTFIELD1)) != 0)
+            case INDEX_INT_FIELD1:
+                if ((bitmask & MASK_INT_FIELD1) != 0)
                 {
-                    optionalOffsets[FIELD_INDEX_INTFIELD1] = fieldLimit;
+                    optionalOffsets[INDEX_INT_FIELD1] = fieldLimit;
                     fieldLimit += FIELD_SIZE_INTFIELD1;
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT64OFUINT8KIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT64OFUINT8KIND)) != 0)
+            case INDEX_VARIANT_OF_INT64:
+                if ((bitmask & MASK_VARIANT_OF_INT64) != 0)
                 {
-                    final VariantUint8KindWithInt64TypeFW variantOfInt64Uint8Kind =
-                        variantOfInt64Uint8KindRO.tryWrap(buffer, fieldLimit, maxLimit);
-                    if (variantOfInt64Uint8Kind == null)
+                    if (variantOfInt64RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
-                    fieldLimit = variantOfInt64Uint8Kind.limit();
+                    fieldLimit = variantOfInt64RO.limit();
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT8ENUMKIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT8ENUMKIND)) != 0)
+            case INDEX_VARIANT_OF_INT8:
+                if ((bitmask & MASK_VARIANT_OF_INT8) != 0)
                 {
-                    final VariantEnumKindOfInt8FW variantOfInt8EnumKind =
-                        variantOfInt8EnumKindRO.tryWrap(buffer, fieldLimit, maxLimit);
-                    if (variantOfInt8EnumKind == null)
+                    if (variantOfInt8RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
-                    fieldLimit = variantOfInt8EnumKind.limit();
+                    fieldLimit = variantOfInt8RO.limit();
                 }
                 break;
-            case FIELD_INDEX_INTFIELD2:
-                if ((bitmask & (1 << FIELD_INDEX_INTFIELD2)) != 0)
+            case INDEX_INT_FIELD2:
+                if ((bitmask & MASK_INT_FIELD2) != 0)
                 {
-                    optionalOffsets[FIELD_INDEX_INTFIELD2] = fieldLimit;
+                    optionalOffsets[INDEX_INT_FIELD2] = fieldLimit;
                     fieldLimit += FIELD_SIZE_INTFIELD2;
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT16ENUMKIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT16ENUMKIND)) != 0)
+            case INDEX_VARIANT_OF_INT16:
+                if ((bitmask & MASK_VARIANT_OF_INT16) != 0)
                 {
-                    final VariantEnumKindOfInt16FW variantOfInt16EnumKind =
-                        variantOfInt16EnumKindRO.tryWrap(buffer, fieldLimit, maxLimit);
-                    if (variantOfInt16EnumKind == null)
+                    if (variantOfInt16RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
-                    fieldLimit = variantOfInt16EnumKind.limit();
+                    fieldLimit = variantOfInt16RO.limit();
                 }
                 break;
-            case FIELD_INDEX_VARIANTOFINT32ENUMKIND:
-                if ((bitmask & (1 << FIELD_INDEX_VARIANTOFINT32ENUMKIND)) != 0)
+            case INDEX_VARIANT_OF_INT32:
+                if ((bitmask & MASK_VARIANT_OF_INT32) != 0)
                 {
-                    final VariantEnumKindWithInt32FW variantOfInt32EnumKind =
-                        variantOfInt32EnumKindRO.tryWrap(buffer, fieldLimit, maxLimit);
-                    if (variantOfInt32EnumKind == null)
+                    if (variantOfInt32RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
                     {
                         return null;
                     }
-                    fieldLimit = variantOfInt32EnumKind.limit();
+                    fieldLimit = variantOfInt32RO.limit();
+                }
+                break;
+            case INDEX_VARIANT_OF_UINT8:
+                if ((bitmask & MASK_VARIANT_OF_UINT8) == 0)
+                {
+                    return null;
+                }
+                if (variantOfUint8RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                {
+                    return null;
+                }
+                fieldLimit = variantOfUint8RO.limit();
+                break;
+            case INDEX_VARIANT_OF_UINT16:
+                if ((bitmask & MASK_VARIANT_OF_UINT16) != 0)
+                {
+                    if (variantOfUint16RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                    {
+                        return null;
+                    }
+                    fieldLimit = variantOfUint16RO.limit();
+                }
+                break;
+            case INDEX_VARIANT_OF_UINT32:
+                if ((bitmask & MASK_VARIANT_OF_UINT32) != 0)
+                {
+                    if (variantOfUint32RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                    {
+                        return null;
+                    }
+                    fieldLimit = variantOfUint32RO.limit();
+                }
+                break;
+            case INDEX_VARIANT_OF_STRING32:
+                if ((bitmask & MASK_VARIANT_OF_STRING32) != 0)
+                {
+                    if (variantOfString32RO.tryWrap(buffer, fieldLimit, maxLimit) == null)
+                    {
+                        return null;
+                    }
+                    fieldLimit = variantOfString32RO.limit();
                 }
                 break;
             }
-        }
-        if (limit() > maxLimit)
-        {
-            return null;
         }
         return this;
     }
@@ -273,59 +412,87 @@ public final class ListWithVariantFW extends Flyweight
     public String toString()
     {
         final long bitmask = bitmask();
-        boolean intField1IsSet = (bitmask & (1 << FIELD_INDEX_INTFIELD1)) != 0;
-        boolean variantOfInt64Uint8KindIsSet = (bitmask & (1 << FIELD_INDEX_VARIANTOFINT64OFUINT8KIND)) != 0;
-        boolean variantOfInt8EnumKindIsSet = (bitmask & (1 << FIELD_INDEX_VARIANTOFINT8ENUMKIND)) != 0;
-        boolean intField2IsSet = (bitmask & (1 << FIELD_INDEX_INTFIELD2)) != 0;
-        boolean variantOfInt16EnumKindIsSet = (bitmask & (1 << FIELD_INDEX_VARIANTOFINT16ENUMKIND)) != 0;
-        boolean variantOfInt32EnumKindIsSet = (bitmask & (1 << FIELD_INDEX_VARIANTOFINT32ENUMKIND)) != 0;
+        Object intField1 = null;
+        Object variantOfInt64 = null;
+        Object variantOfInt8 = null;
+        Object intField2 = null;
+        Object variantOfInt16 = null;
+        Object variantOfInt32 = null;
+        Object variantOfString32 = null;
+
         StringBuilder format = new StringBuilder();
         format.append("LIST_WITH_VARIANT_OF_INT [bitmask={0}");
-        if (intField1IsSet)
+        if ((bitmask & MASK_INT_FIELD1) != 0L)
         {
             format.append(", intField1={1}");
+            intField1 = intField1();
         }
-        if (variantOfInt64Uint8KindIsSet)
+        if ((bitmask & MASK_VARIANT_OF_INT64) != 0L)
         {
-            format.append(", variantOfInt64Uint8Kind={2}");
+            format.append(", variantOfInt64={2}");
+            variantOfInt64 = variantOfInt64();
         }
-        if (variantOfInt8EnumKindIsSet)
+        if ((bitmask & MASK_VARIANT_OF_INT8) != 0)
         {
-            format.append(", variantOfInt8EnumKind={3}");
+            format.append(", variantOfInt8={3}");
+            variantOfInt8 = variantOfInt8();
         }
-        if (intField2IsSet)
+        if ((bitmask & MASK_INT_FIELD2) != 0)
         {
             format.append(", intField2={4}");
+            intField2 = intField2();
         }
-        if (variantOfInt16EnumKindIsSet)
+        if ((bitmask & MASK_VARIANT_OF_INT16) != 0)
         {
-            format.append(", variantOfInt16EnumKind={5}");
+            format.append(", variantOfInt16={5}");
+            variantOfInt16 = variantOfInt16();
         }
-        if (variantOfInt32EnumKindIsSet)
+        if ((bitmask & MASK_VARIANT_OF_INT32) != 0)
         {
-            format.append(", variantOfInt32EnumKind={6}");
+            format.append(", variantOfInt32={6}");
+            variantOfInt32 = variantOfInt32();
+        }
+        format.append(", variantOfUint8={7}");
+        format.append(", variantOfUint16={8}");
+        format.append(", variantOfUint32={9}");
+        if ((bitmask & MASK_VARIANT_OF_STRING32) != 0)
+        {
+            format.append(", variantOfString32={10}");
+            variantOfString32 = variantOfString32();
         }
         format.append("]");
         return MessageFormat.format(format.toString(),
-            String.format("0x%02X", bitmask),
-            intField1IsSet ? intField1() : null,
-            variantOfInt64Uint8KindIsSet ? variantOfInt64Uint8Kind() : null,
-            variantOfInt8EnumKindIsSet ? variantOfInt8EnumKind() : null,
-            intField2IsSet ? intField2() : null,
-            variantOfInt16EnumKindIsSet ? variantOfInt16EnumKind() : null,
-            variantOfInt32EnumKindIsSet ? variantOfInt32EnumKind() : null);
+            String.format("0x%16X", bitmask),
+            intField1,
+            variantOfInt64,
+            variantOfInt8,
+            intField2,
+            variantOfInt16,
+            variantOfInt32,
+            variantOfUint8(),
+            variantOfUint16(),
+            variantOfUint32(),
+            variantOfString32);
     }
 
     public static final class Builder extends Flyweight.Builder<ListWithVariantFW>
     {
-        private final VariantUint8KindWithInt64TypeFW.Builder variantOfInt64Uint8KindRW =
+        private final VariantUint8KindWithInt64TypeFW.Builder variantOfInt64RW =
             new VariantUint8KindWithInt64TypeFW.Builder();
 
-        private final VariantEnumKindOfInt8FW.Builder variantOfInt8EnumKindRW = new VariantEnumKindOfInt8FW.Builder();
+        private final VariantEnumKindOfInt8FW.Builder variantOfInt8RW = new VariantEnumKindOfInt8FW.Builder();
 
-        private final VariantEnumKindOfInt16FW.Builder variantOfInt16EnumKindRW = new VariantEnumKindOfInt16FW.Builder();
+        private final VariantEnumKindOfInt16FW.Builder variantOfInt16RW = new VariantEnumKindOfInt16FW.Builder();
 
-        private final VariantEnumKindWithInt32FW.Builder variantOfInt32EnumKindRW = new VariantEnumKindWithInt32FW.Builder();
+        private final VariantEnumKindWithInt32FW.Builder variantOfInt32RW = new VariantEnumKindWithInt32FW.Builder();
+
+        private final VariantEnumKindOfUint8FW.Builder variantOfUint8RW = new VariantEnumKindOfUint8FW.Builder();
+
+        private final VariantEnumKindOfUint16FW.Builder variantOfUint16RW = new VariantEnumKindOfUint16FW.Builder();
+
+        private final VariantEnumKindOfUint32FW.Builder variantOfUint32RW = new VariantEnumKindOfUint32FW.Builder();
+
+        private final VariantEnumKindWithString32FW.Builder variantOfString32RW = new VariantEnumKindWithString32FW.Builder();
 
         private long fieldsMask;
 
@@ -341,34 +508,40 @@ public final class ListWithVariantFW extends Flyweight
             int newLimit = limit() + FIELD_SIZE_INTFIELD1;
             checkLimit(newLimit, maxLimit());
             buffer().putByte(limit(), value);
-            fieldsMask |= 1 << FIELD_INDEX_INTFIELD1;
+            fieldsMask |= MASK_INT_FIELD1;
             limit(newLimit);
             return this;
         }
 
-        public Builder variantOfInt64Uint8Kind(
+        private VariantUint8KindWithInt64TypeFW.Builder variantOfInt64()
+        {
+            assert (fieldsMask & ~0x01) == 0 : "Field \"variantOfInt64\" cannot be set out of order";
+            return variantOfInt64RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfInt64(
             long value)
         {
-            assert (fieldsMask & ~0x01) == 0 :
-                "Field \"variantOfInt64Uint8Kind\" cannot be set out of order";
-            VariantUint8KindWithInt64TypeFW.Builder variantOfInt64Uint8KindRW = this.variantOfInt64Uint8KindRW.wrap(buffer(),
-                limit(), maxLimit());
-            variantOfInt64Uint8KindRW.set(value);
-            fieldsMask |= 1 << FIELD_INDEX_VARIANTOFINT64OFUINT8KIND;
-            limit(variantOfInt64Uint8KindRW.build().limit());
+            VariantUint8KindWithInt64TypeFW.Builder variantOfInt64RW = variantOfInt64();
+            variantOfInt64RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_INT64;
+            limit(variantOfInt64RW.build().limit());
             return this;
         }
 
-        public Builder variantOfInt8EnumKind(
+        private VariantEnumKindOfInt8FW.Builder variantOfInt8()
+        {
+            assert (fieldsMask & ~0x03) == 0 : "Field \"variantOfInt8\" cannot be set out of order";
+            return variantOfInt8RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfInt8(
             int value)
         {
-            assert (fieldsMask & ~0x03) == 0 :
-                "Field \"variantOfInt8EnumKind\" cannot be set out of order";
-            VariantEnumKindOfInt8FW.Builder variantOfInt8EnumKindRW = this.variantOfInt8EnumKindRW.wrap(buffer(), limit(),
-                maxLimit());
-            variantOfInt8EnumKindRW.set(value);
-            fieldsMask |= 1 << FIELD_INDEX_VARIANTOFINT8ENUMKIND;
-            limit(variantOfInt8EnumKindRW.build().limit());
+            VariantEnumKindOfInt8FW.Builder variantOfInt8RW = variantOfInt8();
+            variantOfInt8RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_INT8;
+            limit(variantOfInt8RW.build().limit());
             return this;
         }
 
@@ -379,34 +552,107 @@ public final class ListWithVariantFW extends Flyweight
             int newLimit = limit() + FIELD_SIZE_INTFIELD2;
             checkLimit(newLimit, maxLimit());
             buffer().putShort(limit(), value);
-            fieldsMask |= 1 << FIELD_INDEX_INTFIELD2;
+            fieldsMask |= MASK_INT_FIELD2;
             limit(newLimit);
             return this;
         }
 
-        public Builder variantOfInt16EnumKind(
+        private VariantEnumKindOfInt16FW.Builder variantOfInt16()
+        {
+            assert (fieldsMask & ~0x0F) == 0 : "Field \"variantOfInt16\" cannot be set out of order";
+            return variantOfInt16RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfInt16(
             int value)
         {
-            assert (fieldsMask & ~0x0F) == 0 :
-                "Field \"variantOfInt16EnumKind\" cannot be set out of order";
-            VariantEnumKindOfInt16FW.Builder variantOfInt16EnumKindRW = this.variantOfInt16EnumKindRW.wrap(buffer(), limit(),
-                maxLimit());
-            variantOfInt16EnumKindRW.set(value);
-            fieldsMask |= 1 << FIELD_INDEX_VARIANTOFINT16ENUMKIND;
-            limit(variantOfInt16EnumKindRW.build().limit());
+            VariantEnumKindOfInt16FW.Builder variantOfInt16RW = variantOfInt16();
+            variantOfInt16RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_INT16;
+            limit(variantOfInt16RW.build().limit());
             return this;
         }
 
-        public Builder variantOfInt32EnumKind(
+        private VariantEnumKindWithInt32FW.Builder variantOfInt32()
+        {
+            assert (fieldsMask & ~0x1F) == 0 : "Field \"variantOfInt32\" cannot be set out of order";
+            return variantOfInt32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfInt32(
             int value)
         {
-            assert (fieldsMask & ~0x1F) == 0 :
-                "Field \"variantOfInt32EnumKind\" cannot be set out of order";
-            VariantEnumKindWithInt32FW.Builder variantOfInt32EnumKindRW = this.variantOfInt32EnumKindRW.wrap(buffer(), limit(),
-                maxLimit());
-            variantOfInt32EnumKindRW.set(value);
-            fieldsMask |= 1 << FIELD_INDEX_VARIANTOFINT32ENUMKIND;
-            limit(variantOfInt32EnumKindRW.build().limit());
+            VariantEnumKindWithInt32FW.Builder variantOfInt32RW = variantOfInt32();
+            variantOfInt32RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_INT32;
+            limit(variantOfInt32RW.build().limit());
+            return this;
+        }
+
+        private VariantEnumKindOfUint8FW.Builder variantOfUint8()
+        {
+            assert (fieldsMask & ~0x3F) == 0 : "Field \"variantOfUint8\" cannot be set out of order";
+            return variantOfUint8RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfUint8(
+            int value)
+        {
+            VariantEnumKindOfUint8FW.Builder variantOfUint8RW = variantOfUint8();
+            variantOfUint8RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_UINT8;
+            limit(variantOfUint8RW.build().limit());
+            return this;
+        }
+
+        private VariantEnumKindOfUint16FW.Builder variantOfUint16()
+        {
+            assert (fieldsMask & ~0x7F) == 0 : "Field \"variantOfUint16\" cannot be set out of order";
+            assert (fieldsMask & 0x40) != 0 : "Prior required field \"variantOfUint8\" is not set";
+            return variantOfUint16RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfUint16(
+            int value)
+        {
+            VariantEnumKindOfUint16FW.Builder variantOfUint16RW = variantOfUint16();
+            variantOfUint16RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_UINT16;
+            limit(variantOfUint16RW.build().limit());
+            return this;
+        }
+
+        private VariantEnumKindOfUint32FW.Builder variantOfUint32()
+        {
+            assert (fieldsMask & ~0xFF) == 0 : "Field \"variantOfUint32\" cannot be set out of order";
+            assert (fieldsMask & 0x40) != 0 : "Prior required field \"variantOfUint8\" is not set";
+            return variantOfUint32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfUint32(
+            long value)
+        {
+            VariantEnumKindOfUint32FW.Builder variantOfUint32RW = variantOfUint32();
+            variantOfUint32RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_UINT32;
+            limit(variantOfUint32RW.build().limit());
+            return this;
+        }
+
+        private VariantEnumKindWithString32FW.Builder variantOfString32()
+        {
+            assert (fieldsMask & ~0x1FF) == 0 : "Field \"variantOfString32\" cannot be set out of order";
+            assert (fieldsMask & 0x40) != 0 : "Prior required field \"variantOfUint8\" is not set";
+            return variantOfString32RW.wrap(buffer(), limit(), maxLimit());
+        }
+
+        public Builder variantOfString32(
+            String value)
+        {
+            VariantEnumKindWithString32FW.Builder variantOfString32RW = variantOfString32();
+            variantOfString32RW.set(value);
+            fieldsMask |= MASK_VARIANT_OF_STRING32;
+            limit(variantOfString32RW.build().limit());
             return this;
         }
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFW.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFW.java
@@ -395,7 +395,10 @@ public final class ListWithVariantFW extends Flyweight
                 break;
             }
         }
-        checkLimit(fieldLimit, limit);
+        if (fieldLimit > limit)
+        {
+            return null;
+        }
         return this;
     }
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithVariantFWTest.java
@@ -29,7 +29,6 @@ import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt8;
 import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint16;
 import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint32;
 import org.reaktivity.reaktor.internal.test.types.inner.EnumWithUint8;
-import org.reaktivity.reaktor.internal.test.types.inner.ListWithVariantFW;
 
 public class ListWithVariantFWTest
 {
@@ -328,6 +327,10 @@ public class ListWithVariantFWTest
             .variantOfInt8(100)
             .variantOfInt16(2000)
             .variantOfInt32(-500)
+            .variantOfUint8(200)
+            .variantOfUint16(50000)
+            .variantOfUint32(4000000000L)
+            .variantOfString32("variant")
             .build()
             .limit();
         listWithVariantOfIntRO.wrap(buffer,  0,  limit);

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -364,7 +364,7 @@ scope test
             uint8 field1 = 1;
         }
 
-//        list[uint32, uint32, 0x40] ListWithDefaultNull
+//        list<uint32, uint32, 0x40> ListWithDefaultNull
 //        {
 //            required VariantEnumKindWithString32 variantOfString1;
 //            VariantEnumKindWithString32 variantOfString2;

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -363,5 +363,13 @@ scope test
             UnionOctets unionOctets;
             uint8 field1 = 1;
         }
+
+//        list[uint32, uint32, 0x40] ListWithDefaultNull
+//        {
+//            required VariantEnumKindWithString32 variantOfString1;
+//            VariantEnumKindWithString32 variantOfString2;
+//            VariantEnumKindOfUint32 variantOfUint = 4000000000;
+//            VariantEnumKindWithInt32 variantOfInt;
+//        }
     }
 }


### PR DESCRIPTION
### List flyweight with default null byte syntax
```
list<physical_size, logical_size, default_null_byte>
{
    // some fields here
}
```
Example:
```
list<uint8, uint8, 0x40>
{
    required string field1;
    uint8 field2 = 100;
}
```
where 
`physical_size` is either `uint8`, `uint16`, `uint32`, `unit64`
and 
`logical_size` is either `uint8`, `uint16`, `uint32`, `unit64`
and 
`default_null_byte` is a single byte hex literal representing a default null byte

When `default_null_byte` is used in a `list` definition, the specified default null byte value gets encoded when a field is not set in the `Builder` class.

In the accessors, if the decoded value was the default null byte, it gives an `AssertionError` saying "Field is not set" or returns a default value if it was specified in the field in the `idl` file.
