### PR TITLE
Update ArrayFW item() methods

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Array16FWGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Array16FWGenerator.java
@@ -518,9 +518,10 @@ public final class Array16FWGenerator extends ClassSpecGenerator
                 .addParameter(consumerType, "consumer")
                 .addStatement("itemRW.wrap(this)")
                 .addStatement("consumer.accept(itemRW)")
-                .addStatement("maxLength = Math.max(maxLength, itemRW.sizeof())")
-                .addStatement("checkLimit(itemRW.limit(), maxLimit())")
-                .addStatement("limit(itemRW.limit())")
+                .addStatement("final V item = itemRW.build()")
+                .addStatement("maxLength = Math.max(maxLength, item.sizeof())")
+                .addStatement("checkLimit(item.limit(), maxLimit())")
+                .addStatement("limit(item.limit())")
                 .addStatement("fieldCount++")
                 .addStatement("return this")
                 .build();

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Array32FWGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Array32FWGenerator.java
@@ -519,9 +519,10 @@ public final class Array32FWGenerator extends ClassSpecGenerator
                 .addParameter(consumerType, "consumer")
                 .addStatement("itemRW.wrap(this)")
                 .addStatement("consumer.accept(itemRW)")
-                .addStatement("maxLength = Math.max(maxLength, itemRW.sizeof())")
-                .addStatement("checkLimit(itemRW.limit(), maxLimit())")
-                .addStatement("limit(itemRW.limit())")
+                .addStatement("final V item = itemRW.build()")
+                .addStatement("maxLength = Math.max(maxLength, item.sizeof())")
+                .addStatement("checkLimit(item.limit(), maxLimit())")
+                .addStatement("limit(item.limit())")
                 .addStatement("fieldCount++")
                 .addStatement("return this")
                 .build();

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Array8FWGenerator.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/generate/Array8FWGenerator.java
@@ -472,9 +472,10 @@ public final class Array8FWGenerator extends ClassSpecGenerator
                 .addParameter(consumerType, "consumer")
                 .addStatement("itemRW.wrap(this)")
                 .addStatement("consumer.accept(itemRW)")
-                .addStatement("maxLength = Math.max(maxLength, itemRW.sizeof())")
-                .addStatement("checkLimit(itemRW.limit(), maxLimit())")
-                .addStatement("limit(itemRW.limit())")
+                .addStatement("final V item = itemRW.build()")
+                .addStatement("maxLength = Math.max(maxLength, item.sizeof())")
+                .addStatement("checkLimit(item.limit(), maxLimit())")
+                .addStatement("limit(item.limit())")
                 .addStatement("fieldCount++")
                 .addStatement("return this")
                 .build();


### PR DESCRIPTION
FW need to build() item when setting item as the flyweight being stored is done being used and therefor build() should be done to signify this.