### PR TITLE
Enhance ListFW

### DIFF
--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/parse/AstParser.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/parse/AstParser.java
@@ -952,6 +952,14 @@ public final class AstParser extends NukleusBaseVisitor<AstNode>
         }
 
         @Override
+        public AstListNode.Builder visitArray_member(
+            Array_memberContext ctx)
+        {
+            listMemberBuilder.type(AstType.ARRAY32);
+            return super.visitArray_member(ctx);
+        }
+
+        @Override
         public Builder visitMember_with_parametric_type(
             Member_with_parametric_typeContext ctx)
         {

--- a/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/visit/ListVisitor.java
+++ b/src/main/java/org/reaktivity/nukleus/maven/plugin/internal/ast/visit/ListVisitor.java
@@ -16,10 +16,12 @@
 package org.reaktivity.nukleus.maven.plugin.internal.ast.visit;
 
 import static java.util.Collections.singleton;
+import static java.util.stream.Collectors.toList;
 import static org.reaktivity.nukleus.maven.plugin.internal.ast.AstNamedNode.Kind.MAP;
 import static org.reaktivity.nukleus.maven.plugin.internal.ast.AstNamedNode.Kind.VARIANT;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -40,6 +42,7 @@ import org.reaktivity.nukleus.maven.plugin.internal.generate.TypeResolver;
 import org.reaktivity.nukleus.maven.plugin.internal.generate.TypeSpecGenerator;
 
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 
 public final class ListVisitor extends AstNode.Visitor<Collection<TypeSpecGenerator<?>>>
@@ -86,53 +89,74 @@ public final class ListVisitor extends AstNode.Visitor<Collection<TypeSpecGenera
         ClassName originalMapKeyName = null;
         ClassName originalMapValueName = null;
 
-        AstNamedNode memberTypeNode = resolver.resolve(memberType.name());
-        if (memberTypeNode != null)
-        {
-            if (memberTypeNode.getKind() == VARIANT)
-            {
-                AstVariantNode varNode = (AstVariantNode) memberTypeNode;
-                AstType ofType = varNode.of();
-                if (AstType.ARRAY.equals(ofType))
-                {
-                    AstType arrayType = listMemberNode.typeParams().get(0);
-                    arrayItemTypeName = arrayType;
-                }
-                else if (AstType.MAP.equals(ofType))
-                {
-                    mapKeyType = listMemberNode.typeParams().get(0);
-                    mapValueType = listMemberNode.typeParams().get(1);
-                }
-            }
-            else if (memberTypeNode.getKind() == MAP)
-            {
-                AstMapNode mapNode = (AstMapNode) memberTypeNode;
-                AstType keyType = mapNode.keyType();
-                AstType valueType = mapNode.valueType();
-                AstType mapParam = listMemberNode.typeParams().get(0);
-                mapParamName = resolver.resolveClass(mapParam);
-                originalMapKeyName = Objects.requireNonNullElse(resolver.resolveClass(keyType), mapParamName);
-                originalMapValueName = Objects.requireNonNullElse(resolver.resolveClass(valueType), mapParamName);
-            }
-        }
-
         int size = listMemberNode.size();
         TypeName sizeTypeName = listMemberNode.sizeType() == null ? null : listMemberNode.sizeType().isUnsignedInt() ?
-            resolver.resolveUnsignedType(listMemberNode.sizeType()) : resolver.resolveType(listMemberNode.sizeType());
+                        resolver.resolveUnsignedType(listMemberNode.sizeType()) : resolver.resolveType(listMemberNode.sizeType());
         boolean usedAsSize = listMemberNode.usedAsSize();
         Object defaultValue = listMemberNode.defaultValue();
         AstByteOrder byteOrder = listMemberNode.byteOrder();
 
-        TypeName memberTypeName = resolver.resolveType(memberType);
-        if (memberTypeName == null)
+        if (memberType == AstType.ARRAY32)
         {
-            throw new IllegalArgumentException(String.format(
-                " Unable to resolve type %s for field %s", memberType, memberName));
+            ClassName rawType = resolver.resolveClass(memberType);
+            TypeName[] typeArguments = memberNode.types()
+                                                 .stream()
+                                                 .skip(1)
+                                                 .map(resolver::resolveType)
+                                                 .collect(toList())
+                                                 .toArray(new TypeName[0]);
+            ParameterizedTypeName memberTypeName = ParameterizedTypeName.get(rawType, typeArguments);
+            List<AstType> memberTypes = memberNode.types();
+            AstType memberUnsignedType = memberTypes.get(1);
+            TypeName memberUnsignedTypeName = resolver.resolveUnsignedType(memberUnsignedType);
+
+            generator.addMember(memberName, memberType, memberTypeName, memberUnsignedTypeName, usedAsSize,
+                defaultValue, byteOrder, listMemberNode.isRequired(), arrayItemTypeName, mapKeyType, mapValueType,
+                mapParamName, originalMapKeyName, originalMapValueName);
         }
-        TypeName memberUnsignedTypeName = memberType.isUnsignedInt() ? resolver.resolveUnsignedType(memberType) : null;
-        generator.addMember(memberName, memberType, memberTypeName, memberUnsignedTypeName, usedAsSize,
-            defaultValue, byteOrder, listMemberNode.isRequired(), arrayItemTypeName, mapKeyType, mapValueType,
-            mapParamName, originalMapKeyName, originalMapValueName);
+        else
+        {
+            AstNamedNode memberTypeNode = resolver.resolve(memberType.name());
+            if (memberTypeNode != null)
+            {
+                if (memberTypeNode.getKind() == VARIANT)
+                {
+                    AstVariantNode varNode = (AstVariantNode) memberTypeNode;
+                    AstType ofType = varNode.of();
+                    if (AstType.ARRAY.equals(ofType))
+                    {
+                        AstType arrayType = listMemberNode.typeParams().get(0);
+                        arrayItemTypeName = arrayType;
+                    }
+                    else if (AstType.MAP.equals(ofType))
+                    {
+                        mapKeyType = listMemberNode.typeParams().get(0);
+                        mapValueType = listMemberNode.typeParams().get(1);
+                    }
+                }
+                else if (memberTypeNode.getKind() == MAP)
+                {
+                    AstMapNode mapNode = (AstMapNode) memberTypeNode;
+                    AstType keyType = mapNode.keyType();
+                    AstType valueType = mapNode.valueType();
+                    AstType mapParam = listMemberNode.typeParams().get(0);
+                    mapParamName = resolver.resolveClass(mapParam);
+                    originalMapKeyName = Objects.requireNonNullElse(resolver.resolveClass(keyType), mapParamName);
+                    originalMapValueName = Objects.requireNonNullElse(resolver.resolveClass(valueType), mapParamName);
+                }
+            }
+
+            TypeName memberTypeName = resolver.resolveType(memberType);
+            if (memberTypeName == null)
+            {
+                throw new IllegalArgumentException(String.format(
+                    " Unable to resolve type %s for field %s", memberType, memberName));
+            }
+            TypeName memberUnsignedTypeName = memberType.isUnsignedInt() ? resolver.resolveUnsignedType(memberType) : null;
+            generator.addMember(memberName, memberType, memberTypeName, memberUnsignedTypeName, usedAsSize,
+                defaultValue, byteOrder, listMemberNode.isRequired(), arrayItemTypeName, mapKeyType, mapValueType,
+                mapParamName, originalMapKeyName, originalMapValueName);
+        }
         return defaultResult();
     }
 

--- a/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithArrayOfStructFWTest.java
+++ b/src/test/java/org/reaktivity/nukleus/maven/plugin/internal/generated/ListWithArrayOfStructFWTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2016-2020 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.nukleus.maven.plugin.internal.generated;
+
+import static java.nio.ByteBuffer.allocateDirect;
+import static org.junit.Assert.assertEquals;
+
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+import org.reaktivity.reaktor.internal.test.types.inner.EnumWithInt8;
+import org.reaktivity.reaktor.internal.test.types.inner.ListWithArrayOfStructFW;
+
+public class ListWithArrayOfStructFWTest
+{
+    private final MutableDirectBuffer buffer = new UnsafeBuffer(allocateDirect(100))
+    {
+        {
+            // Make sure the code is not secretly relying upon memory being initialized to 0
+            setMemory(0, capacity(), (byte) 0xab);
+        }
+    };
+    private final ListWithArrayOfStructFW.Builder listWithArrayRW = new ListWithArrayOfStructFW.Builder();
+    private final ListWithArrayOfStructFW listWithArrayRO = new ListWithArrayOfStructFW();
+    private final int lengthSize = Byte.BYTES;
+    private final int fieldCountSize = Byte.BYTES;
+    private final byte kindList8 = EnumWithInt8.TWO.value();
+    private final int kindSize = Byte.BYTES;
+    private final byte kindArray8 = EnumWithInt8.EIGHT.value();
+    private final byte kindString8 = EnumWithInt8.NINE.value();
+
+    @Test
+    public void shouldSetAllFields() throws Exception
+    {
+        int limit = listWithArrayRW.wrap(buffer, 0, buffer.capacity())
+            .requiredField("string0")
+            .arrayFieldItem(c -> c.fixed1(1L))
+            .arrayFieldItem(c -> c.fixed1(2L))
+            .build()
+            .limit();
+
+        final ListWithArrayOfStructFW listWithArray = listWithArrayRO.wrap(buffer, 0, limit);
+
+        assertEquals(48, listWithArray.limit());
+        assertEquals(2, listWithArray.fieldCount());
+    }
+}

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -415,15 +415,10 @@ scope test
                VariantOfInt32;
         }
 
-        struct Field
+        list<uint32, uint32> ListWithArrayOfStruct
         {
-            string16 field;
-        }
-
-        list<uint32, uint32> ListWithPlainArray
-        {
-            required string8 field0;
-            Field[] field1;
+            required string8 requiredField;
+            FlatParent[] arrayField;
         }
 
         list<uint32, uint32> ListWithPhysicalAndLogicalLength

--- a/src/test/resources/test-project/test.idl
+++ b/src/test/resources/test-project/test.idl
@@ -415,6 +415,17 @@ scope test
                VariantOfInt32;
         }
 
+        struct Field
+        {
+            string16 field;
+        }
+
+        list<uint32, uint32> ListWithPlainArray
+        {
+            required string8 field0;
+            Field[] field1;
+        }
+
         list<uint32, uint32> ListWithPhysicalAndLogicalLength
         {
             required string8 field0;


### PR DESCRIPTION
- Support parameterized types in list structures in .idl
    - as of now, it treats any [] type as just the member type. ie. `uint32[]` is treated as just `uint32`
- Add `<array>Item()` method functionality to list structure FW